### PR TITLE
Best practices report

### DIFF
--- a/Check/BestPractices/Multisite.php
+++ b/Check/BestPractices/Multisite.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\BestPractices\Multisite.
+ */
+
+class SiteAuditCheckBestPracticesMultisite extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Multi-site');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Detect multi-site configurations.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+    return dt('The following multi-site configuration(s) were detected: @list', array(
+      '@list' => implode(', ', $this->registry['multisites']),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    return $this->getResultFail();
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('No multi-sites detected.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL) {
+      return dt('See https://www.getpantheon.com/blog/much-ado-about-drupal-multisite for details.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    if (is_file($drupal_root . '/sites/sites.php')) {
+      $handle = opendir($drupal_root . '/sites/');
+      $this->registry['multisites'] = array();
+      while (FALSE !== ($entry = readdir($handle))) {
+        if (!in_array($entry, array(
+          '.',
+          '..',
+          'default',
+          'all',
+          'example.sites.php',
+          'README.txt',
+          '.svn',
+          '.DS_Store',
+        ))
+        ) {
+          if (is_dir($drupal_root . '/sites/' . $entry)) {
+            $this->registry['multisites'][] = $entry;
+          }
+        }
+      }
+      closedir($handle);
+      if (!empty($this->registry['multisites'])) {
+        if (drush_get_option('vendor') == 'pantheon') {
+          return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+        }
+        return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+      }
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+
+}

--- a/Check/BestPractices/Multisite.php
+++ b/Check/BestPractices/Multisite.php
@@ -66,7 +66,7 @@ class SiteAuditCheckBestPracticesMultisite extends SiteAuditCheckAbstract {
         return dt('See https://www.drupal.org/node/2297419 for details on how to use multisite feature in Drupal 8.');
       }
       else {
-        return dt('Create sites.php file inside sites directory by copying example.sites.php file. See https://www.drupal.org/node/2297419 for more details.');
+        return dt('Inside the sites/ directory, copy example.sites.php to sites.php to create the configuration. See https://www.drupal.org/node/2297419 for details.');
       }
     }
   }

--- a/Check/BestPractices/Services.php
+++ b/Check/BestPractices/Services.php
@@ -51,7 +51,7 @@ class SiteAuditCheckBestPracticesServices extends SiteAuditCheckAbstract {
       return dt('Don\'t rely on symbolic links for core configuration files; copy services.yml where it should be and remove the symbolic link.');
     }
     if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL) {
-      return dt('Create services.yml file inside sites/default directory by copying default.services.yml');
+      return dt('Create services.yml file inside sites/default directory by copying default.services.yml file. See https://www.drupal.org/documentation/install/settings-file for details.');
     }
   }
 

--- a/Check/BestPractices/Services.php
+++ b/Check/BestPractices/Services.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\BestPractices\Service.
+ */
+
+class SiteAuditCheckBestPracticesServices extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('sites/default/services.yml');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check if the services file exists.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('service.yml exists and is not a symbolic link.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return dt('sites/default/services.yml is a symbolic link.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Don\'t rely on symbolic links for core configuration files; copy services.yml where it should be and remove the symbolic link.');
+    }
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL) {
+      return dt('Create services.yml file inside sites/default directory by copying default.services.yml');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    if (file_exists($drupal_root . '/sites/default/services.yml')) {
+      if (is_link($drupal_root . '/sites/default/services.yml')) {
+        return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+      }
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+  }
+}

--- a/Check/BestPractices/Services.php
+++ b/Check/BestPractices/Services.php
@@ -22,7 +22,9 @@ class SiteAuditCheckBestPracticesServices extends SiteAuditCheckAbstract {
   /**
    * Implements \SiteAudit\Check\Abstract\getResultFail().
    */
-  public function getResultFail() {}
+  public function getResultFail() {
+    return dt('services.yml does not exist! Copy the default.service.yml to services.yml and see https://www.drupal.org/documentation/install/settings-file for details.');
+  }
 
   /**
    * Implements \SiteAudit\Check\Abstract\getResultInfo().
@@ -33,7 +35,7 @@ class SiteAuditCheckBestPracticesServices extends SiteAuditCheckAbstract {
    * Implements \SiteAudit\Check\Abstract\getResultPass().
    */
   public function getResultPass() {
-    return dt('service.yml exists and is not a symbolic link.');
+    return dt('services.yml exists and is not a symbolic link.');
   }
 
   /**

--- a/Check/BestPractices/Settings.php
+++ b/Check/BestPractices/Settings.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\BestPractices\Settings.
+ */
+
+class SiteAuditCheckBestPracticesSettings extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('sites/default/settings.php');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check if the configuration file exists.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('settings.php exists and is not a symbolic link.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return dt('sites/default/settings.php is a symbolic link.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Don\'t rely on symbolic links for core configuration files; copy settings.php where it should be and remove the symbolic link.');
+    }
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL) {
+      return dt('Even if environment settings are injected, create a stub settings.php file for compatibility.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    if (file_exists($drupal_root . '/sites/default/settings.php')) {
+      if (is_link($drupal_root . '/sites/default/settings.php')) {
+        return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+      }
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+  }
+}

--- a/Check/BestPractices/Sites.php
+++ b/Check/BestPractices/Sites.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\BestPractices\Settings.
+ */
+
+class SiteAuditCheckBestPracticesSites extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('sites/sites.php');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check if multisite configuration file is a symbolic link.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    if ($this->registry['multisite_enabled']) {
+      return dt('sites.php is not a symbolic link.');
+    }
+    else {
+      return dt('sites.php does not exist.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return dt('sites/sites.php is a symbolic link.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Don\'t rely on symbolic links for core configuration files; copy sites.php where it should be and remove the symbolic link.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $this->registry['multisite_enabled'] = file_exists($drupal_root . '/sites/sites.php');
+    if ($this->registry['multisite_enabled'] && is_link($drupal_root . '/sites/sites.php')) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+
+}

--- a/Check/BestPractices/SitesDefault.php
+++ b/Check/BestPractices/SitesDefault.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\BestPractices\SitesDefault.
+ */
+
+class SiteAuditCheckBestPracticesSitesDefault extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('sites/default');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check if it exists and isn\'t symbolic');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+    return dt('sites/default does not exist!');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('sites/default is a directory and not a symbolic link.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return dt('sites/default exists as a symbolic link.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL) {
+      return dt('sites/default is necessary; recreate the directory immediately.');
+    }
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Avoid changing Drupal\'s site structure; remove the symbolic link and recreate sites/default.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    if (is_dir($drupal_root . '/sites/default')) {
+      if (is_link($drupal_root . '/sites/default')) {
+        return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+      }
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+  }
+
+}

--- a/Check/BestPractices/SitesSuperfluous.php
+++ b/Check/BestPractices/SitesSuperfluous.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\BestPractices\SitesSuperfluous.
+ */
+
+class SiteAuditCheckBestPracticesSitesSuperfluous extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Superfluous files in /sites');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Detect unnecessary files.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('No unnecessary files detected.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return dt('The following extra files were detected: @list', array(
+      '@list' => implode(', ', $this->registry['superfluous']),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Unless you have an explicit need for it, don\'t store anything other than settings here.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $handle = opendir($drupal_root . '/sites/');
+    $this->registry['superfluous'] = array();
+    while (FALSE !== ($entry = readdir($handle))) {
+      if (!in_array($entry, array(
+        '.',
+        '..',
+        'default',
+        'all',
+        'example.sites.php',
+        'development.services.yml',
+        'example.settings.local.php',
+        'README.txt',
+        '.DS_Store',
+      ))) {
+        if (is_file($drupal_root . '/sites/' . $entry)) {
+          // Support multi-site directory aliasing for non-Pantheon sites.
+          if ($entry != 'sites.php' || drush_get_option('vendor') == 'pantheon') {
+            $this->registry['superfluous'][] = $entry;
+          }
+        }
+      }
+    }
+    closedir($handle);
+    if (!empty($this->registry['superfluous'])) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+}

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -72,6 +72,7 @@ function site_audit_drush_command() {
     'options' => array_merge(site_audit_common_options(), $vendor_options),
     'checks' => array(
       'Fast404',
+      'Multisite',
     ),
   );
 

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -72,6 +72,7 @@ function site_audit_drush_command() {
     'options' => array_merge(site_audit_common_options(), $vendor_options),
     'checks' => array(
       'Fast404',
+      'Sites',
       'Multisite',
       'Settings',
       'Services',

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -76,6 +76,7 @@ function site_audit_drush_command() {
       'Multisite',
       'Settings',
       'Services',
+      'SitesDefault',
     ),
   );
 

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -73,6 +73,7 @@ function site_audit_drush_command() {
     'checks' => array(
       'Fast404',
       'Multisite',
+      'Settings',
     ),
   );
 

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -74,6 +74,7 @@ function site_audit_drush_command() {
       'Fast404',
       'Multisite',
       'Settings',
+      'Services',
     ),
   );
 

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -77,6 +77,7 @@ function site_audit_drush_command() {
       'Settings',
       'Services',
       'SitesDefault',
+      'SitesSuperfluous',
     ),
   );
 


### PR DESCRIPTION
Issue #14 
### Sites

Checks if `sites/sites.php` is a symbolic link
- [x] Pass - Either `sites.php` does not exist or `sites.php` exists and is not a symbolic link.
- [x] Warn - `sites.php` exists and is a symbolic link.
### Multisite

There is just a small difference between Drupal 7 and Drupal 8 multisite. In Drupal 8, `sites.php` file must exist in `sites` directory to enable multisite feature. Therefore, I have put an additional if statement in the code to check for the file.
- [x] Pass - do not modify the sites directory
- [x] Info - run these commands inside the sites directory `cp example.sites.php sites.php` and `mkdir site1`
- [x] Warn - Either `sites.php` is present and multisite directories not present or the other way round
- [x] Fail - run with multisite enabled and option --vendor=pantheon
### Settings

No changes from Drupal 7 version
- [x] Pass - run on default installation
- [x] Warn - make `settings.php` file inside `sites/default` a symlink
- [x] Fail - when settings.php file is not present. Drush fails to bootstrap in this case, so site_audit should fail to run
### Services

Similar to Settings check
- [x] Pass - run on default installation. `services.yml` file is present inside `sites/default` directory and is not a symlink
- [x] Warn - make `services.yml` file inside `sites/default` a symlink
- [x] Fail - delete the  `services.yml` file from `sites/default`  directory
## SitesDefault
- [x] Pass - run on default installation
- [x] Warn - make `sites/default` directory a symlink
- [x] Fail - Remove `sites/default` directory
## SitesSuperfluous
- [x] Pass - run on default installation
- [x] Warn - create any file other than `sites.php` inside `sites` directory.
### Sites All/Default/Superfluous
- `/sites/all/{modules,themes,libraries,profiles}` directories from Drupal 7 has been moved to `/{modules,themes,libraries,profiles}` in Drupal 8
- `sites/all` is still supported in Drupal 8, but not needed.
- `sites/default` is same as Drupal 7
- There are new files inside sites directory - `development.services.yml` and `example.settings.local.php`.
- Recommendations - No need for SitesAll check. We can have a check for `/{modules,themes,libraries,profiles}` direcotries. Keep SitesDefault and SitesSuperfluous checks same.
