### PR TITLE
Codebase report

### DIFF
--- a/Check/Codebase/ManagedFileCount.php
+++ b/Check/Codebase/ManagedFileCount.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Codebase\ManagedFileCount.
+ */
+
+class SiteAuditCheckCodebaseManagedFileCount extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Drupal managed file count');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Determine the count of Drupal managed files.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    return dt('Managed file count: @count', array(
+      '@count' => number_format($this->registry['managed_file_count']),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $sql_query  = 'SELECT COUNT(fid) ';
+    $sql_query .= 'FROM {file_managed} ';
+    $sql_query .= 'WHERE status = 1 ';
+    $this->registry['managed_file_count'] = db_query($sql_query)->fetchField();
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Check/Codebase/ManagedFileSize.php
+++ b/Check/Codebase/ManagedFileSize.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Codebase\ManagedFileSize.
+ */
+
+class SiteAuditCheckCodebaseManagedFileSize extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Drupal managed file size');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Determine the size of Drupal managed files.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    if ($this->registry['managed_filesize'] < 1048576) {
+      return dt('Managed file size: @managed_filesize_kbkB', array(
+        '@managed_filesize_kb' => number_format($this->registry['managed_filesize'] / 1024, 2),
+      ));
+    }
+    return dt('Managed file size: @managed_filesize_mbMB', array(
+      '@managed_filesize_mb' => number_format($this->registry['managed_filesize'] / 1048576, 2),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    if (!$this->registry['managed_file_count']) {
+      $this->registry['managed_filesize'] = 0;
+    }
+    else {
+      $sql_query  = 'SELECT SUM(filesize) ';
+      $sql_query .= 'FROM {file_managed} ';
+      $sql_query .= 'WHERE status = 1 ';
+      $this->registry['managed_filesize'] = db_query($sql_query)->fetchField();
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Check/Codebase/SizeAll.php
+++ b/Check/Codebase/SizeAll.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Codebase\SizeAll.
+ */
+
+class SiteAuditCheckCodebaseSizeAll extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Size of entire site');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Determine the size of the site root; does not include remote mounts.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+    return dt('Unable to determine size of site root!');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    if ($this->registry['size_all_kb'] < 1024) {
+      return dt('Total size: @size_all_kbkB', array(
+        '@size_all_kb' => number_format($this->registry['size_all_kb']),
+      ));
+    }
+    return dt('Total size: @size_all_mbMB', array(
+      '@size_all_mb' => number_format($this->registry['size_all_kb'] / 1024, 2),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    exec('du -s -k -x ' . $drupal_root, $result);
+    $this->registry['size_all_kb'] = trim($result[0]);
+    if (!$this->registry['size_all_kb']) {
+      $this->abort = TRUE;
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Check/Codebase/SizeFiles.php
+++ b/Check/Codebase/SizeFiles.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Codebase\SizeFiles.
+ */
+
+class SiteAuditCheckCodebaseSizeFiles extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    $settings = \Drupal::service('settings');
+    $kernel = \Drupal::service('kernel');
+    return dt('Size of @files_folder', array('@files_folder' => $settings->get('file_public_path', $kernel->getSitePath() . '/files')));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    $settings = \Drupal::service('settings');
+    $kernel = \Drupal::service('kernel');
+    return dt('Determine the size of @files_folder.', array('@files_folder' => $settings->get('file_public_path', $kernel->getSitePath() . '/files')));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+    $settings = \Drupal::service('settings');
+    $kernel = \Drupal::service('kernel');
+    return dt('Unable to determine size of @files_folder!', array('@files_folder' => $settings->get('file_public_path', $kernel->getSitePath() . '/files')));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    if ($this->registry['size_files_kb'] < 1024) {
+      return dt('Files: @size_files_kbkB', array(
+        '@size_files_kb' => number_format($this->registry['size_files_kb']),
+      ));
+    }
+    return dt('Files: @size_files_mbMB', array(
+      '@size_files_mb' => number_format($this->registry['size_files_kb'] / 1024, 2),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $settings = \Drupal::service('settings');
+    $kernel = \Drupal::service('kernel');
+    exec('du -s -k -x ' . $drupal_root . '/' . $settings->get('file_public_path', $kernel->getSitePath() . '/files') . '/', $result);
+    $size_files_kb_exploded = explode("\t", trim($result[0]));
+    $this->registry['size_files_kb'] = $size_files_kb_exploded[0];
+    if (!$this->registry['size_files_kb']) {
+      $this->abort = TRUE;
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Check/Codebase/SizeFiles.php
+++ b/Check/Codebase/SizeFiles.php
@@ -9,27 +9,21 @@ class SiteAuditCheckCodebaseSizeFiles extends SiteAuditCheckAbstract {
    * Implements \SiteAudit\Check\Abstract\getLabel().
    */
   public function getLabel() {
-    $settings = \Drupal::service('settings');
-    $kernel = \Drupal::service('kernel');
-    return dt('Size of @files_folder', array('@files_folder' => $settings->get('file_public_path', $kernel->getSitePath() . '/files')));
+    return dt('Size of public:// folder');
   }
 
   /**
    * Implements \SiteAudit\Check\Abstract\getDescription().
    */
   public function getDescription() {
-    $settings = \Drupal::service('settings');
-    $kernel = \Drupal::service('kernel');
-    return dt('Determine the size of @files_folder.', array('@files_folder' => $settings->get('file_public_path', $kernel->getSitePath() . '/files')));
+    return dt('Determine the size of public:// folder.');
   }
 
   /**
    * Implements \SiteAudit\Check\Abstract\getResultFail().
    */
   public function getResultFail() {
-    $settings = \Drupal::service('settings');
-    $kernel = \Drupal::service('kernel');
-    return dt('Unable to determine size of @files_folder!', array('@files_folder' => $settings->get('file_public_path', $kernel->getSitePath() . '/files')));
+    return dt('Unable to determine size of public://!');
   }
 
   /**

--- a/Report/Codebase.php
+++ b/Report/Codebase.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Report\Codebase.
+ */
+
+class SiteAuditReportCodebase extends SiteAuditReportAbstract {
+  /**
+   * Implements \SiteAudit\Report\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Codebase');
+  }
+
+}

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -85,6 +85,16 @@ function site_audit_drush_command() {
     ),
   );
 
+  $items['audit-codebase'] = array(
+    'description' => dt('Audit the codebase.'),
+    'aliases' => array('acb'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+    'options' => site_audit_common_options(),
+    'checks' => array(
+      'ManagedFileCount',
+    ),
+  );
+
   $items['audit-extensions'] = array(
     'description' => dt('Audit extensions (modules and themes).'),
     'aliases' => array('ae'),
@@ -104,6 +114,7 @@ function site_audit_drush_command() {
     'reports' => array(
       'BestPractices',
       'Cache',
+      'Codebase',
       'Extensions',
     ),
   );
@@ -357,5 +368,20 @@ function drush_site_audit_audit_extensions_validate() {
  */
 function drush_site_audit_audit_extensions() {
   $report = new SiteAuditReportExtensions();
+  $report->render();
+}
+
+/**
+ * Audit codebase validation.
+ */
+function drush_site_audit_audit_codebase_validate() {
+  return site_audit_version_check();
+}
+
+/**
+ * Audit the executable codebase of a Drupal site.
+ */
+function drush_site_audit_audit_codebase() {
+  $report = new SiteAuditReportCodebase();
   $report->render();
 }

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -92,6 +92,7 @@ function site_audit_drush_command() {
     'options' => site_audit_common_options(),
     'checks' => array(
       'ManagedFileCount',
+      'ManagedFileSize',
     ),
   );
 

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -91,6 +91,7 @@ function site_audit_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
     'options' => site_audit_common_options(),
     'checks' => array(
+      'SizeFiles',
       'SizeAll',
       'ManagedFileCount',
       'ManagedFileSize',

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -91,6 +91,7 @@ function site_audit_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
     'options' => site_audit_common_options(),
     'checks' => array(
+      'SizeAll',
       'ManagedFileCount',
       'ManagedFileSize',
     ),


### PR DESCRIPTION
Issue #17 
### Managed File Count

Same as Drupal 7
- [x] Info - Make a content type with `File` field and add some dummy content, then run this check  
### Managed File Size

Same as Drupal 7
- [x] Info - Make a content type with `File` field and add some dummy content, then run this check
### Size All

Same as Drupal 7
- [x] Info - Gives the size of drupal root
- [x] Fail - don't know how to make it fail
### Size Files

Very few changes from drupal 7
- [x] Info - Gives the size of `sites/default/files`
- [x] Fail - don't know how to make it fail
