### PR TITLE
Added Cron checks

### DIFF
--- a/Check/Cron/Enabled.php
+++ b/Check/Cron/Enabled.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Cron\Enabled.
+ */
+
+/**
+ * Class SiteAuditCheckCronEnabled.
+ */
+class SiteAuditCheckCronEnabled extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Enabled');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check to see if cron is scheduled to run.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+    return dt('You have disabled cron, which will prevent routine system tasks from executing.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    // Manual execution.
+    if ($this->registry['cron_safe_threshold'] === 0) {
+      return dt('Drupal Cron frequency is set to never, but has been executed within the past 24 hours (either manually or using drush cron).');
+    }
+    // Default.
+    return dt('Cron is set to run every @minutes minutes.', array(
+      '@minutes' => round($this->registry['cron_safe_threshold'] / 60),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    if ($this->registry['cron_safe_threshold'] > (24 * 60 * 60)) {
+      return dt('Drupal Cron frequency is set to mare than 24 hours.');
+    }
+    else {
+      return dt("Drupal Cron has not run in the past day even though it's frequency has been set to less than 24 hours.");
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL) {
+      return dt('Please visit /admin/config/system/cron and set the cron frequency to something other than Never but less than 24 hours.');
+    }
+    elseif ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      if ($this->registry['cron_safe_threshold'] > (24 * 60 * 60)) {
+        return dt('Please visit /admin/config/system/cron and set the cron frequency to something less than 24 hours.');
+      }
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    // Determine when cron last ran.
+    $this->registry['cron_last'] = \Drupal::state()->get('system.cron_last');
+    $this->registry['cron_safe_threshold'] = \Drupal::config('system.cron')->get('threshold.autorun');
+
+    // Cron hasn't run in the past day.
+    if ((time() - $this->registry['cron_last']) > (24 * 60 * 60)) {
+      if ($this->registry['cron_safe_threshold'] === 0) {
+        return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+      }
+      else {
+        return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+      }
+    }
+    elseif ($this->registry['cron_safe_threshold'] > (24 * 60 * 60)) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+
+}

--- a/Check/Cron/Last.php
+++ b/Check/Cron/Last.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Cron\Last.
+ */
+
+/**
+ * Class SiteAuditCheckCronLast.
+ */
+class SiteAuditCheckCronLast extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Last run');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Time Cron last executed');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    if ($this->registry['cron_last']) {
+      return dt('Cron last ran at @date (@ago ago)', array(
+        '@date' => date('r', $this->registry['cron_last']),
+        '@ago' => \Drupal::service('date.formatter')->formatInterval(time() - $this->registry['cron_last']),
+      ));
+    }
+    return dt('Cron has never run.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Report/Cron.php
+++ b/Report/Cron.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Report\Cron.
+ */
+
+/**
+ * Class SiteAuditReportCron.
+ */
+class SiteAuditReportCron extends SiteAuditReportAbstract {
+  /**
+   * Implements \SiteAudit\Report\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Cron');
+  }
+
+}

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -109,6 +109,17 @@ function site_audit_drush_command() {
     ),
   );
 
+  $items['audit-cron'] = array(
+    'description' => dt('Audit cron.'),
+    'aliases' => array('acr'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+    'options' => site_audit_common_options(),
+    'checks' => array(
+      'Enabled',
+      'Last',
+    ),
+  );
+
   $items['audit-extensions'] = array(
     'description' => dt('Audit extensions (modules and themes).'),
     'aliases' => array('ae'),
@@ -364,6 +375,21 @@ function drush_site_audit_audit_best_practices() {
   $report->render();
 }
 
+
+/**
+ * Audit cron validation.
+ */
+function drush_site_audit_audit_cron_validate() {
+  return site_audit_version_check();
+}
+
+/**
+ * Render a Cron report.
+ */
+function drush_site_audit_audit_cron() {
+  $report = new SiteAuditReportCron();
+  $report->render();
+}
 /**
  * Audit extensions validation.
  */

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -141,6 +141,7 @@ function site_audit_drush_command() {
       'Cache',
       'Codebase',
       'Extensions',
+      'Cron',
     ),
   );
 


### PR DESCRIPTION
Issue #19 
### Enabled
- [x] Pass - cron frequency is set to less than 24 hours (default drupal installation) and cron has run in the past day.
- [x] Warn - go to `/admin/config/system/cron` and set the cron frequency to less than 24 hours, or when cron frequency less than 24 hours but cron has not run in the past day.
- [x] Fail - go to `/admin/config/system/cron` and set the cron frequency to Never, then ensure that cron has not run in the past day
### Last
- [x] Info - Outputs the time when cron last ran.
