### PR TITLE
Extensions report

### DIFF
--- a/Check/Extensions/Dev.php
+++ b/Check/Extensions/Dev.php
@@ -130,7 +130,7 @@ class SiteAuditCheckExtensionsDev extends SiteAuditCheckAbstract {
       // Reason.
       $row[] = $dev_extensions[$extension->getName()];
 
-      $this->registry['extensions_dev'][$extension->name] = $row;
+      $this->registry['extensions_dev'][$extension->getName()] = $row;
     }
 
     if (!empty($this->registry['extensions_dev'])) {

--- a/Check/Extensions/Dev.php
+++ b/Check/Extensions/Dev.php
@@ -152,6 +152,7 @@ class SiteAuditCheckExtensionsDev extends SiteAuditCheckAbstract {
   public function getExtensions() {
     $developer_modules = array(
       'ipsum' => dt('Development utility to generate fake content.'),
+      'testmodule' => dt('Internal test module.'),
       // Examples module.
       'block_example' => dt('Development examples.'),
       'cache_example' => dt('Development examples.'),

--- a/Check/Extensions/Dev.php
+++ b/Check/Extensions/Dev.php
@@ -103,7 +103,6 @@ class SiteAuditCheckExtensionsDev extends SiteAuditCheckAbstract {
     $extension_info = $this->registry['extensions'];
     uasort($extension_info, '_drush_pm_sort_extensions');
     $dev_extensions = $this->getExtensions();
-
     foreach ($extension_info as $key => $extension) {
       $row = array();
       $status = drush_get_extension_status($extension);
@@ -114,7 +113,7 @@ class SiteAuditCheckExtensionsDev extends SiteAuditCheckAbstract {
       }
 
       // Not in the list of known development modules.
-      if (!array_key_exists($extension->name, $dev_extensions)) {
+      if (!array_key_exists($extension->getName(), $dev_extensions)) {
         unset($extension_info[$key]);
         continue;
       }
@@ -129,7 +128,7 @@ class SiteAuditCheckExtensionsDev extends SiteAuditCheckAbstract {
       // Name.
       $row[] = $extension->label;
       // Reason.
-      $row[] = $dev_extensions[$extension->name];
+      $row[] = $dev_extensions[$extension->getName()];
 
       $this->registry['extensions_dev'][$extension->name] = $row;
     }

--- a/Check/Extensions/Dev.php
+++ b/Check/Extensions/Dev.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Extensions\Dev.
+ */
+
+/**
+ * Class SiteAuditCheckExtensionsDev.
+ */
+class SiteAuditCheckExtensionsDev extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Development');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check for enabled development modules.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    return $this->getResultWarn();
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('No enabled development extensions were detected; no action required.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    $ret_val = dt('The following development modules(s) are currently enabled: @list', array(
+      '@list' => implode(', ', array_keys($this->registry['extensions_dev'])),
+    ));
+    $show_table = TRUE;
+    if (site_audit_env_is_dev()) {
+      $show_table = FALSE;
+    }
+
+    if (drush_get_option('detail')) {
+      if (drush_get_option('html')) {
+        if ($show_table) {
+          $ret_val .= '<br/>';
+          $ret_val .= '<table class="table table-condensed">';
+          $ret_val .= '<thead><tr><th>Name</th><th>Reason</th></thead>';
+          $ret_val .= '<tbody>';
+          foreach ($this->registry['extensions_dev'] as $row) {
+            $ret_val .= '<tr><td>' . implode('</td><td>', $row) . '</td></tr>';
+          }
+          $ret_val .= '</tbody>';
+          $ret_val .= '</table>';
+        }
+      }
+      elseif ($show_table) {
+        foreach ($this->registry['extensions_dev'] as $row) {
+          $ret_val .= PHP_EOL;
+          if (!drush_get_option('json')) {
+            $ret_val .= str_repeat(' ', 6);
+          }
+          $ret_val .= '- ' . $row[0] . ': ' . $row[1];
+        }
+      }
+    }
+    return $ret_val;
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->getScore() == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      $show_action = TRUE;
+      if (site_audit_env_is_dev()) {
+        $show_action = FALSE;
+      }
+      if ($show_action) {
+        return dt('Disable development modules for increased stability, security and performance in the Live (production) environment.');
+      }
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $this->registry['extensions_dev'] = array();
+    $extension_info = $this->registry['extensions'];
+    uasort($extension_info, '_drush_pm_sort_extensions');
+    $dev_extensions = $this->getExtensions();
+
+    foreach ($extension_info as $key => $extension) {
+      $row = array();
+      $status = drush_get_extension_status($extension);
+      // Only enabled extensions.
+      if (!in_array($status, array('enabled'))) {
+        unset($extension_info[$key]);
+        continue;
+      }
+
+      // Not in the list of known development modules.
+      if (!array_key_exists($extension->name, $dev_extensions)) {
+        unset($extension_info[$key]);
+        continue;
+      }
+
+      // Do not report modules that are dependencies of other modules, such
+      // as field_ui in Drupal Commerce.
+      if (isset($extension->required_by) && !empty($extension->required_by)) {
+        unset($extension_info[$key]);
+        continue;
+      }
+
+      // Name.
+      $row[] = $extension->label;
+      // Reason.
+      $row[] = $dev_extensions[$extension->name];
+
+      $this->registry['extensions_dev'][$extension->name] = $row;
+    }
+
+    if (!empty($this->registry['extensions_dev'])) {
+      if (site_audit_env_is_dev()) {
+        return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+      }
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+
+  /**
+   * Get a list of development extension names and reasons.
+   *
+   * @return array
+   *   Keyed by module machine name, value is explanation.
+   */
+  public function getExtensions() {
+    $developer_modules = array(
+      'ipsum' => dt('Development utility to generate fake content.'),
+      // Examples module.
+      'block_example' => dt('Development examples.'),
+      'cache_example' => dt('Development examples.'),
+      'config_entity_example' => dt('Development examples.'),
+      'content_entity_example' => dt('Development examples.'),
+      'dbtng_example' => dt('Development examples.'),
+      'email_example' => dt('Development examples.'),
+      'examples' => dt('Development examples.'),
+      'field_example' => dt('Development examples.'),
+      'field_permission_example' => dt('Development examples.'),
+      'file_example' => dt('Development examples.'),
+      'js_example' => dt('Development examples.'),
+      'node_type_example' => dt('Development examples.'),
+      'page_example' => dt('Development examples.'),
+      'phpunit_example' => dt('Development examples.'),
+      'simpletest_example' => dt('Development examples.'),
+      'tablesort_example' => dt('Development examples.'),
+      'tour_example' => dt('Development examples.'),
+    );
+
+    // From http://drupal.org/project/admin_menu admin_menu.inc in function
+    // _admin_menu_developer_modules().
+    $admin_menu_developer_modules = array(
+      'admin_devel' => dt('Debugging utility; degrades performance.'),
+      'cache_disable' => dt('Development utility and performance drain; degrades performance.'),
+      'coder' => dt('Debugging utility; potential security risk and unnecessary performance hit.'),
+      'content_copy' => dt('Development utility; unnecessary overhead.'),
+      'context_ui' => dt('Development user interface; unnecessary overhead.'),
+      'debug' => dt('Debugging utility; potential security risk, unnecessary overhead.'),
+      'delete_all' => dt('Development utility; potentially dangerous.'),
+      'demo' => dt('Development utility for sandboxing.'),
+      'devel' => dt('Debugging utility; degrades performance and potential security risk.'),
+      'devel_node_access' => dt('Development utility; degrades performance and potential security risk.'),
+      'devel_themer' => dt('Development utility; degrades performance and potential security risk.'),
+      'field_ui' => dt('Development user interface; allows privileged users to change site structure which can lead to data inconsistencies. Best practice is to store Content Types in code and deploy changes instead of allowing editing in live environments.'),
+      'fontyourface_ui' => dt('Development user interface; unnecessary overhead.'),
+      'form_controller' => dt('Development utility; unnecessary overhead.'),
+      'imagecache_ui' => dt('Development user interface; unnecessary overhead.'),
+      'journal' => dt('Development utility; unnecessary overhead.'),
+      'l10n_client' => dt('Development utility; unnecessary overhead.'),
+      'l10n_update' => dt('Development utility; unnecessary overhead.'),
+      'macro' => dt('Development utility; unnecessary overhead.'),
+      'rules_admin' => dt('Development user interface; unnecessary overhead.'),
+      'stringoverrides' => dt('Development utility.'),
+      'trace' => dt('Debugging utility; degrades performance and potential security risk.'),
+      'upgrade_status' => dt('Development utility for performing a major Drupal core update; should removed after use.'),
+      'user_display_ui' => dt('Development user interface; unnecessary overhead.'),
+      'util' => dt('Development utility; unnecessary overhead, potential security risk.'),
+      'views_ui' => dt('Development UI; allows privileged users to change site structure which can lead to performance problems or inconsistent behavior. Best practice is to store Views in code and deploy changes instead of allowing editing in live environments.'),
+      'views_theme_wizard' => dt('Development utility; unnecessary overhead, potential security risk.'),
+    );
+
+    return array_merge($admin_menu_developer_modules, $developer_modules);
+  }
+
+}

--- a/Check/Extensions/Dev.php
+++ b/Check/Extensions/Dev.php
@@ -58,7 +58,7 @@ class SiteAuditCheckExtensionsDev extends SiteAuditCheckAbstract {
         if ($show_table) {
           $ret_val .= '<br/>';
           $ret_val .= '<table class="table table-condensed">';
-          $ret_val .= '<thead><tr><th>Name</th><th>Reason</th></thead>';
+          $ret_val .= '<thead><tr><th>' . dt('Name') . '</th><th>' . dt('Reason') . '</th></thead>';
           $ret_val .= '<tbody>';
           foreach ($this->registry['extensions_dev'] as $row) {
             $ret_val .= '<tr><td>' . implode('</td><td>', $row) . '</td></tr>';

--- a/Check/Extensions/Duplicate.php
+++ b/Check/Extensions/Duplicate.php
@@ -170,13 +170,19 @@ class SiteAuditCheckExtensionsDuplicate extends SiteAuditCheckAbstract {
       if ($paths_in_profile > 0 &&
           count($instances) - $paths_in_profile == 1 &&
           drush_get_extension_status($extension_object) == 'enabled' &&
-          $extension_object->info['version'] == $instances[$non_profile_index]['version']) {
+          $extension_object->info['version'] == $instances[$non_profile_index]['version'] &&
+          $instances[$non_profile_index]['version'] != '') {
         $skip = TRUE;
         foreach ($instances as $index => $info) {
-          if ($index != $non_profile_index) {
+          if ($index != $non_profile_index && $info['version'] != '') {
             if (version_compare($instances[$non_profile_index]['version'], $info['version']) < 1) {
               $skip = FALSE;
+              break;
             }
+          }
+          elseif ($info['version'] == '') {
+            $skip = FALSE;
+            break;
           }
         }
         if ($skip === TRUE) {

--- a/Check/Extensions/Duplicate.php
+++ b/Check/Extensions/Duplicate.php
@@ -141,10 +141,15 @@ class SiteAuditCheckExtensionsDuplicate extends SiteAuditCheckAbstract {
         continue;
       }
 
-      // If every path is within an installation profile, ignore.
       $paths_in_profile = 0;
       $non_profile_index = 0;
+      $test_extensions = 0;
       foreach ($instances as $index => $instance) {
+        // Ignore if it is a test extension.
+        if (strpos($instance['path'], '/tests/') !== FALSE) {
+          $test_extensions++;
+          continue;
+        }
         if (strpos($instance['path'], 'profiles/') === 0) {
           $paths_in_profile++;
         }
@@ -152,7 +157,9 @@ class SiteAuditCheckExtensionsDuplicate extends SiteAuditCheckAbstract {
           $non_profile_index = $index;
         }
       }
-      if ($paths_in_profile == count($instances)) {
+      // If every path is within an installation profile
+      // or is a test extension, ignore.
+      if ($paths_in_profile + $test_extensions == count($instances)) {
         unset($this->registry['extensions_dupe'][$extension]);
         continue;
       }

--- a/Check/Extensions/Duplicate.php
+++ b/Check/Extensions/Duplicate.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Extensions\Duplicate.
+ */
+
+/**
+ * Class SiteAuditCheckExtensionsDuplicate.
+ */
+class SiteAuditCheckExtensionsDuplicate extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Duplicates');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check for duplicate extensions in the site codebase.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('No duplicate extensions were detected.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    $ret_val = dt('The following duplicate extensions were found:');
+    if (drush_get_option('html')) {
+      $ret_val = '<p>' . $ret_val . '</p>';
+      $ret_val .= '<table class="table table-condensed">';
+      $ret_val .= '<thead><tr><th>' . dt('Name') . '</th><th>' . dt('Paths') . '</th></thead>';
+      $ret_val .= '<tbody>';
+      foreach ($this->registry['extensions_dupe'] as $name => $paths) {
+        $ret_val .= '<tr><td>' . $name . '</td>';
+        $ret_val .= '<td>' . implode('<br/>', $paths) . '</td></tr>';
+      }
+      $ret_val .= '</tbody>';
+      $ret_val .= '</table>';
+    }
+    else {
+      foreach ($this->registry['extensions_dupe'] as $name => $paths) {
+        $ret_val .= PHP_EOL;
+        if (!drush_get_option('json')) {
+          $ret_val .= str_repeat(' ', 6);
+        }
+        $ret_val .= $name . PHP_EOL;
+        $extension_list = '';
+        foreach ($paths as $path) {
+          $extension_list .= str_repeat(' ', 8) . $path . PHP_EOL;
+        }
+        $ret_val .= rtrim($extension_list);
+      }
+    }
+    return $ret_val;
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score != SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS) {
+      return dt('Prune your codebase to have only one copy of any given extension. If you are using an installation profile, work with the maintainer to update the relevant modules. If you remove an enabled module, you may have to rebuild the registry.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $this->registry['extensions_dupe'] = array();
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $settings = \Drupal::service('settings');
+    $kernel = \Drupal::service('kernel');
+    $command = "find $drupal_root -xdev -type f -name '*.info.yml' -o -path './" . $settings->get('file_public_path', $kernel->getSitePath() . '/files') . "' -prune";
+    exec($command, $result);
+
+    foreach ($result as $path) {
+      $path_parts = explode('/', $path);
+      $name = substr(array_pop($path_parts), 0, -9);
+      // Safe duplicates.
+      if (in_array($name, array(
+        'drupal_system_listing_compatible_test',
+        'drupal_system_listing_incompatible_test',
+        'aaa_update_test',
+      ))) {
+        continue;
+      }
+      if (!isset($this->registry['extensions_dupe'][$name])) {
+        $this->registry['extensions_dupe'][$name] = array();
+      }
+      $path = substr($path, strlen($drupal_root) + 1);
+      $info = file($drupal_root . '/' . $path);
+      foreach ($info as $line) {
+        if (strpos($line, 'version') === 0) {
+          $version = explode(':', $line);
+          if (isset($version[1])) {
+            $path .= ' (' . trim(str_replace("'", '', $version[1])) . ')';
+          }
+        }
+      }
+      $this->registry['extensions_dupe'][$name][] = $path;
+    }
+
+    // Review the detected extensions.
+    foreach ($this->registry['extensions_dupe'] as $extension => $paths) {
+      // No duplicates.
+      if (count($paths) == 1) {
+        unset($this->registry['extensions_dupe'][$extension]);
+        continue;
+      }
+
+      // If every path is within an installation profile, ignore.
+      $paths_in_profile = 0;
+      foreach ($paths as $path) {
+        if (strpos($path, 'profiles/') === 0) {
+          $paths_in_profile++;
+        }
+      }
+      if ($paths_in_profile == count($paths)) {
+        unset($this->registry['extensions_dupe'][$extension]);
+        continue;
+      }
+    }
+
+    // Determine score.
+    if (count($this->registry['extensions_dupe'])) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+
+}

--- a/Check/Extensions/Duplicate.php
+++ b/Check/Extensions/Duplicate.php
@@ -123,7 +123,7 @@ class SiteAuditCheckExtensionsDuplicate extends SiteAuditCheckAbstract {
           $version_split = explode(':', $line);
           if (isset($version_split[1])) {
             $version .= trim(str_replace("'", '', $version_split[1]));
-            $path = $path . '(' . $version . ')';
+            $path = $path . ' (' . $version . ')';
           }
         }
       }

--- a/Check/Extensions/Unrecommended.php
+++ b/Check/Extensions/Unrecommended.php
@@ -135,6 +135,15 @@ class SiteAuditCheckExtensionsUnrecommended extends SiteAuditCheckAbstract {
       'bad_judgement' => dt('Joke module, framework for anarchy.'),
       'php' => dt('Executable code should never be stored in the database.'),
     );
+    if (drush_get_option('vendor') == 'pantheon') {
+      // Unsupported or redundant.
+      $pantheon_unrecommended_modules = array(
+        'memcache' => dt('Pantheon does not provide memcache; instead, redis is provided as a service to all customers; see http://helpdesk.getpantheon.com/customer/portal/articles/401317'),
+        'memcache_storage' => dt('Pantheon does not provide memcache; instead, redis is provided as a service to all customers; see http://helpdesk.getpantheon.com/customer/portal/articles/401317'),
+        'backup_migrate' => dt("On Pantheon, Backup & Migrate makes your Drupal site work harder and degrades site performance; instead, use Pantheon's Backup through the site dashboard, which won't affect site performance."),
+      );
+      $unrecommended_modules = array_merge($unrecommended_modules, $pantheon_unrecommended_modules);
+    }
     return $unrecommended_modules;
   }
 

--- a/Check/Extensions/Unrecommended.php
+++ b/Check/Extensions/Unrecommended.php
@@ -129,7 +129,6 @@ class SiteAuditCheckExtensionsUnrecommended extends SiteAuditCheckAbstract {
       $pantheon_unrecommended_modules = array(
         'memcache' => dt('Pantheon does not provide memcache; instead, redis is provided as a service to all customers; see http://helpdesk.getpantheon.com/customer/portal/articles/401317'),
         'memcache_storage' => dt('Pantheon does not provide memcache; instead, redis is provided as a service to all customers; see http://helpdesk.getpantheon.com/customer/portal/articles/401317'),
-        'backup_migrate' => dt("On Pantheon, Backup & Migrate makes your Drupal site work harder and degrades site performance; instead, use Pantheon's Backup through the site dashboard, which won't affect site performance."),
       );
       $unrecommended_modules = array_merge($unrecommended_modules, $pantheon_unrecommended_modules);
     }

--- a/Check/Extensions/Unrecommended.php
+++ b/Check/Extensions/Unrecommended.php
@@ -33,7 +33,7 @@ class SiteAuditCheckExtensionsUnrecommended extends SiteAuditCheckAbstract {
       if (drush_get_option('html')) {
         $ret_val .= '<br/>';
         $ret_val .= '<table class="table table-condensed">';
-        $ret_val .= '<thead><tr><th>Name</th><th>Reason</th></thead>';
+        $ret_val .= '<thead><tr><th>' . dt('Name') . '</th><th>' . dt('Reason') . '</th></thead>';
         $ret_val .= '<tbody>';
         foreach ($this->registry['extensions_unrec'] as $row) {
           $ret_val .= '<tr><td>' . implode('</td><td>', $row) . '</td></tr>';
@@ -94,24 +94,13 @@ class SiteAuditCheckExtensionsUnrecommended extends SiteAuditCheckAbstract {
 
       $machine_name = $extension->getName();
 
-      // Get the human readable name of the extension.
-      $human_readable_name = '';
-      if (isset($extension->info['name'])) {
-        $human_readable_name = $extension->info['name'];
-      }
-      else {
-        $human_readable_name = $machine_name;
-      }
-
-      // Construct label.
-      $label = $human_readable_name . ' (' . $machine_name . ')';
       // Not in the list of known unrecommended modules.
       if (!array_key_exists($machine_name, $unrecommended_extensions)) {
         continue;
       }
 
       // Name.
-      $row[] = $label;
+      $row[] = $extension->label;
       // Reason.
       $row[] = $unrecommended_extensions[$machine_name];
 

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -149,6 +149,7 @@ function site_audit_drush_command() {
     'options' => array_merge(site_audit_common_options(), $vendor_options),
     'checks' => array(
       'Count',
+      'Dev',
       'Unrecommended',
     ),
   );

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -150,6 +150,7 @@ function site_audit_drush_command() {
     'checks' => array(
       'Count',
       'Dev',
+      'Duplicate',
       'Unrecommended',
     ),
   );

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -154,6 +154,11 @@ function site_audit_drush_command() {
       'Unrecommended',
     ),
   );
+  $items['audit-extensions']['options']['extension_count'] = array(
+    'description' => dt('Specify threshold for average number of extensions'),
+    'example-value' => dt('150'),
+    'value' => 'required',
+  );
 
   $items['audit-all'] = array(
     'description' => dt('Executes every Site Audit Report'),


### PR DESCRIPTION
Issue #28 
### Count

Was already implemented
### Unrecommended

Was already implemented. Just added a few more modules to the unrecommended list
### Dev

Admin menu module no longer has a list of dev modules. I have not removed the list of those modules from the check.
- [x] Pass - No dev module enabled. Passes on default installation
- [x] Info - When a dev modules is enabled on dev environment of Pantheon
- [x] Warn -When a dev module is enabled. Check this by installing `ipsum` module using `drush en ipsum`
### Duplicate
- [ ]  Pass - No two extensions with the same name are present in the website
- [ ]  Warn - Two extensions with the same name are present in the codebase. Ignores the extensions are within an installation profile, or if greater version of a module than what is in an installation profile is enabled.
  To test this, I downloaded [DruStack profile](http://ftp.drupal.org/files/projects/drustack-7.x-38.87-no-core.tar.gz) and placed it in the `profile` directory of the drupal root. Then in the `drustack/drustack.info.yml` file, I added `php` module under the dependencies key (any other module will work here, just place the new dependency added inside `drustack/modules/contrib` directory). Then I installed drupal using `DruStack` profile. Now, we can place a newer/older version the same module under the `modules` directory and the depending on the version, site_audit will either warn or pass this test.
