### PR TITLE
Watchdog Report

### DIFF
--- a/Check/Watchdog/404.php
+++ b/Check/Watchdog/404.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Watchdog\404.
+ */
+
+/**
+ * Class SiteAuditCheckWatchdog404.
+ */
+class SiteAuditCheckWatchdog404 extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Number of 404 entries');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Count the number of page not found entries.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    return dt('@count_404 pages not found (@percent_404%).', array(
+      '@count_404' => $this->registry['count_404'],
+      '@percent_404' => $this->registry['percent_404'],
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('No 404 entries.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return $this->getResultInfo();
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Review the full report at admin/reports/page-not-found. If self-inflicted, fix the source. If a redirect is appropriate, visit admin/config/search/path and add URL aliases.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $sql_query  = 'SELECT COUNT(wid) ';
+    $sql_query .= 'FROM {watchdog} ';
+    $sql_query .= 'WHERE type=:type';
+    $this->registry['count_404'] = db_query($sql_query, array(
+      ':type' => 'page not found',
+    ))->fetchField();
+    $this->registry['percent_404'] = 0;
+
+    // @TODO: Aggregate 404 entries and return top 10.
+    if (!$this->registry['count_404']) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+    }
+    $this->registry['percent_404'] = round(($this->registry['count_404'] / $this->registry['count_entries']) * 100);
+    if ($this->registry['percent_404'] >= 10) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Check/Watchdog/Age.php
+++ b/Check/Watchdog/Age.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Watchdog\Age.
+ */
+
+/**
+ * Class SiteAuditCheckWatchdogAge.
+ */
+class SiteAuditCheckWatchdogAge extends SiteAuditCheckAbstract {
+  public $ageNewest;
+  public $ageOldest;
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Date range of log entries');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Oldest and newest.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    // If two different days...
+    if (date('Y-m-d', $this->ageOldest) != date('Y-m-d', $this->ageNewest)) {
+      return dt('From @from to @to (@days days)', array(
+        '@from' => date('r', $this->ageOldest),
+        '@to' => date('r', $this->ageNewest),
+        '@days' => round(($this->ageNewest - $this->ageOldest) / 86400, 2),
+      ));
+    }
+    // Same day; don't calculate number of days.
+    return dt('From @from to @to', array(
+      '@from' => date('r', $this->ageOldest),
+      '@to' => date('r', $this->ageNewest),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    // Age of oldest entry.
+    $sql_query  = 'SELECT timestamp ';
+    $sql_query .= 'FROM {watchdog} ';
+    $sql_query .= 'ORDER BY wid ASC ';
+    $sql_query .= 'LIMIT 1 ';
+    $this->ageOldest = db_query($sql_query)->fetchField();
+
+    // Age of newest entry.
+    $sql_query  = 'SELECT timestamp ';
+    $sql_query .= 'FROM {watchdog} ';
+    $sql_query .= 'ORDER BY wid DESC ';
+    $sql_query .= 'LIMIT 1 ';
+    $this->ageNewest = db_query($sql_query)->fetchField();
+
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Check/Watchdog/Count.php
+++ b/Check/Watchdog/Count.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Watchdog\Count.
+ */
+
+/**
+ * Class SiteAuditCheckWatchdogCount.
+ */
+class SiteAuditCheckWatchdogCount extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Count');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Number of dblog entries.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    if (!$this->registry['count_entries']) {
+      return dt('There are no dblog entries.');
+    }
+    return dt('There are @count_entries log entries.', array(
+      '@count_entries' => number_format($this->registry['count_entries']),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $sql_query  = 'SELECT COUNT(wid) ';
+    $sql_query .= 'FROM {watchdog} ';
+    $this->registry['count_entries'] = db_query($sql_query)->fetchField();
+    if (!$this->registry['count_entries']) {
+      $this->abort = TRUE;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Check/Watchdog/Enabled.php
+++ b/Check/Watchdog/Enabled.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Watchdog\Enabled.
+ */
+
+/**
+ * Class SiteAuditCheckWatchdogEnabled.
+ */
+class SiteAuditCheckWatchdogEnabled extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('dblog status');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check to see if database logging is enabled');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    return dt('Database logging (dblog) is not enabled; if the site is having problems, consider enabling it for debugging.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('Database logging (dblog) is enabled.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    if (!\Drupal::moduleHandler()->moduleExists('dblog')) {
+      $this->abort = TRUE;
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+
+}

--- a/Check/Watchdog/Php.php
+++ b/Check/Watchdog/Php.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Watchdog\Php.
+ */
+
+/**
+ * Class SiteAuditCheckWatchdogPhp.
+ */
+class SiteAuditCheckWatchdogPhp extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('PHP messages');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Count PHP notices, warnings and errors.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    $counts = array();
+    foreach ($this->registry['php_counts'] as $severity => $count) {
+      $counts[] = $severity . ': ' . $count;
+    }
+    $ret_val = implode(', ', $counts);
+    $ret_val .= ' - total ' . $this->registry['percent_php'] . '%';
+    return $ret_val;
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('No PHP warnings, notices or errors.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return $this->getResultInfo();
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Every time Drupal logs a PHP notice, warning or error, PHP executes slower and the writing operation locks the database. By eliminating the problems, your site will be faster.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $this->registry['php_counts'] = array();
+    $this->registry['php_count_total'] = 0;
+    $this->registry['percent_php'] = 0;
+
+    $types = drush_watchdog_message_types();
+    if (array_search('php', $types) === FALSE) {
+      $this->abort = TRUE;
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+    }
+
+    $where = core_watchdog_query('php', NULL, NULL);
+    $rsc = drush_db_select('watchdog', '*', $where['where'], $where['args'], 0, NULL, 'wid', 'DESC');
+    while ($result = drush_db_fetch_object($rsc)) {
+      $row = core_watchdog_format_result($result);
+      if (!isset($this->registry['php_counts'][$row->severity])) {
+        $this->registry['php_counts'][$row->severity] = 0;
+      }
+      $this->registry['php_counts'][$row->severity]++;
+      $this->registry['php_count_total']++;
+    }
+
+    $this->registry['percent_php'] = round(($this->registry['php_count_total'] / $this->registry['count_entries']) * 100, 2);
+    if ($this->registry['percent_php'] >= 10) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Check/Watchdog/Php.php
+++ b/Check/Watchdog/Php.php
@@ -4,6 +4,7 @@
  * Contains \SiteAudit\Check\Watchdog\Php.
  */
 
+use Drupal\Core\Logger\RfcLogLevel;
 /**
  * Class SiteAuditCheckWatchdogPhp.
  */
@@ -80,7 +81,9 @@ class SiteAuditCheckWatchdogPhp extends SiteAuditCheckAbstract {
     $where = core_watchdog_query('php', NULL, NULL);
     $rsc = drush_db_select('watchdog', '*', $where['where'], $where['args'], 0, NULL, 'wid', 'DESC');
     while ($result = drush_db_fetch_object($rsc)) {
+      $severity = $result->severity;
       $row = core_watchdog_format_result($result);
+      $row->severity = RfcLogLevel::getLevels()[$severity]->render();
       if (!isset($this->registry['php_counts'][$row->severity])) {
         $this->registry['php_counts'][$row->severity] = 0;
       }

--- a/Check/Watchdog/Syslog.php
+++ b/Check/Watchdog/Syslog.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Watchdog\Syslog.
+ */
+
+/**
+ * Class SiteAuditCheckWatchdogSyslog.
+ */
+class SiteAuditCheckWatchdogSyslog extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('syslog status');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check to see if syslog logging is enabled');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+    return dt('Syslog logging is enabled!');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    if ($this->registry['syslog_enabled']) {
+      return dt('Syslog logging is enabled.');
+    }
+    return dt('Syslog logging is not enabled.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return $this->getResultInfo();
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->getScore() == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL && drush_get_option('vendor') == 'pantheon') {
+      return dt('On Pantheon, you can technically write to syslog, but there is no mechanism for reading it. Disable syslog and enable dblog instead.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $this->registry['syslog_enabled'] = \Drupal::moduleHandler()->moduleExists('syslog');
+    if ($this->registry['syslog_enabled']) {
+      if (drush_get_option('vendor') == 'pantheon') {
+        return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+      }
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+  }
+
+}

--- a/Report/Watchdog.php
+++ b/Report/Watchdog.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Report\Watchdog.
+ */
+
+/**
+ * Class SiteAuditReportWatchdog.
+ */
+class SiteAuditReportWatchdog extends SiteAuditReportAbstract {
+  /**
+   * Implements \SiteAudit\Report\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Watchdog database logs');
+  }
+
+}

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -193,6 +193,21 @@ function site_audit_drush_command() {
     ),
   );
 
+  $items['audit-watchdog'] = array(
+    'description' => dt('Audit the database logs.'),
+    'aliases' => array('aw'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+    'options' => array_merge(site_audit_common_options(), $vendor_options),
+    'checks' => array(
+      'Syslog',
+      'Enabled',
+      'Count',
+      'Age',
+      '404',
+      'Php',
+    ),
+  );
+
   $items['audit-all'] = array(
     'description' => dt('Executes every Site Audit Report'),
     'aliases' => array('aa'),
@@ -207,6 +222,7 @@ function site_audit_drush_command() {
       'Cron',
       'Database',
       'Users',
+      'Watchdog',
     ),
   );
 
@@ -530,9 +546,24 @@ function drush_site_audit_audit_users_validate() {
 }
 
 /**
+ * Audit watchdog validation.
+ */
+function drush_site_audit_audit_watchdog_validate() {
+  return site_audit_version_check();
+}
+
+/**
  * Render a Users report.
  */
 function drush_site_audit_audit_users() {
   $report = new SiteAuditReportUsers();
+  $report->render();
+}
+
+/**
+ * Audit the database logs of a Drupal site.
+ */
+function drush_site_audit_audit_watchdog() {
+  $report = new SiteAuditReportWatchdog();
   $report->render();
 }


### PR DESCRIPTION
This report is straightforward with minor changes.
### Syslog
- [x] Info - Checks whether `syslog` module is enabled or disabled
### Enabled
- [x] Info - `dblog` module is disabled. This aborts rest of the checks
- [x] Pass - `dblog` module is enabled
### Count
- [x] Info -  Counts the number of watchdog entries
### Age
- [x] Info - Outputs the age of the oldest and newest entries in watchdog
### 404
- [x] Info - Outputs number of page not found entries
### Php
- [x] Info - Outputs the number of watchdog entries whose type is `php` along with their severity. Also gives the percent of errors that are `php`.
- [x] Warn - If the percentage of errors of type `php` is > 10. Easiest way to test this is to go to phpmyadmin - watchdog table of the database - `click on search` - search for rows with type php - click on copy option of any row - insert the row at least nine times. Now on running the check, you will get a warning.  
