### PR TITLE
Views Report

### DIFF
--- a/Check/Views/CacheOutput.php
+++ b/Check/Views/CacheOutput.php
@@ -19,7 +19,7 @@ class SiteAuditCheckViewsCacheOutput extends SiteAuditCheckAbstract {
    * Implements \SiteAudit\Check\Abstract\getDescription().
    */
   public function getDescription() {
-    return dt('Check the length of time raw rendered output should be cached.');
+    return dt('Check to see if raw rendered output is being cached.');
   }
 
   /**
@@ -65,7 +65,7 @@ class SiteAuditCheckViewsCacheOutput extends SiteAuditCheckAbstract {
           dt('Select the Display'),
           dt('Click Advanced'),
           dt('Next to Caching, click to edit.'),
-          dt('Rendered output: (something other than Never cache)'),
+          dt('Caching: (something other than None)'),
         );
         if (drush_get_option('html') == TRUE) {
           $ret_val .= '<ol><li>' . implode('</li><li>', $steps) . '</li></ol>';

--- a/Check/Views/CacheOutput.php
+++ b/Check/Views/CacheOutput.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Views\CacheOutput.
+ */
+
+class SiteAuditCheckViewsCacheOutput extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Rendered output caching');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check the length of time raw rendered output should be cached.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+    return dt('No View is caching rendered output!');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    return $this->getResultWarn();
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('Every View is caching rendered output.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return dt('The following Views are not caching rendered output: @views_without_output_caching', array(
+      '@views_without_output_caching' => implode(', ', $this->registry['views_without_output_caching']),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if (!in_array($this->score, array(SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO, SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS))) {
+      $ret_val = dt('Rendered output should be cached for as long as possible (if the query changes, the output will be refreshed).');
+      if (drush_get_option('detail')) {
+        $steps = array(
+          dt('Go to /admin/structure/views/'),
+          dt('Edit the View in question'),
+          dt('Select the Display'),
+          dt('Click Advanced'),
+          dt('Next to Caching, click to edit.'),
+          dt('Rendered output: (something other than Never cache)'),
+        );
+        if (drush_get_option('html') == TRUE) {
+          $ret_val .= '<ol><li>' . implode('</li><li>', $steps) . '</li></ol>';
+        }
+        else {
+          foreach ($steps as $step) {
+            $ret_val .= PHP_EOL;
+            if (!drush_get_option('json')) {
+              $ret_val .= str_repeat(' ', 8);
+            }
+            $ret_val .= '- ' . $step;
+          }
+        }
+      }
+      return $ret_val;
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $this->registry['output_lifespan'] = array();
+    foreach ($this->registry['views'] as $view) {
+      // Skip views used for administration purposes.
+      if (in_array($view->get('tag'), array('admin', 'commerce'))) {
+        continue;
+      }
+      foreach ($view->get('display') as $display_name => $display) {
+        if (!isset($display['display_options']['enabled']) || $display['display_options']['enabled']) {
+          // Default display OR overriding display.
+          if (isset($display['display_options']['cache'])) {
+            if ($display['display_options']['cache']['type'] == 'none' || ($display['display_options']['cache'] == '')) {
+              if ($display_name == 'default') {
+                $this->registry['output_lifespan'][$view->get('id')]['default'] = 'none';
+              }
+              else {
+                $this->registry['output_lifespan'][$view->get('id')]['displays'][$display_name] = 'none';
+              }
+            }
+            elseif ($display['display_options']['cache']['type'] == 'time') {
+              if ($display['display_options']['cache']['options']['output_lifespan'] == 0) {
+                $lifespan = $display['display_options']['cache']['options']['output_lifespan_custom'];
+              }
+              else {
+                $lifespan = $display['display_options']['cache']['options']['output_lifespan'];
+              }
+              if ($lifespan < 1) {
+                $lifespan = 'none';
+              }
+              if ($display_name == 'default') {
+                $this->registry['output_lifespan'][$view->get('id')]['default'] = $lifespan;
+              }
+              else {
+                $this->registry['output_lifespan'][$view->get('id')]['displays'][$display_name] = $lifespan;
+              }
+            }
+            elseif ($display['display_options']['cache']['type'] == 'tag') {
+              if ($display_name == 'default') {
+                $this->registry['output_lifespan'][$view->get('id')]['default'] = 'tag';
+              }
+              else {
+                $this->registry['output_lifespan'][$view->get('id')]['displays'][$display_name] = 'tag';
+              }
+            }
+          }
+          // Display is using default display's caching.
+          else {
+            $this->registry['output_lifespan'][$view->get('id')]['displays'][$display_name] = 'default';
+          }
+        }
+      }
+    }
+
+    $this->registry['views_without_output_caching'] = array();
+
+    foreach ($this->registry['output_lifespan'] as $view_name => $view_data) {
+      // Views with only master display.
+      if (!isset($view_data['displays']) || (count($view_data['displays']) == 0)) {
+        if ($view_data['default'] == 'none') {
+          $this->registry['views_without_output_caching'][] = $view_name;
+        }
+      }
+      else {
+        // If all the displays are default, consolidate.
+        $all_default_displays = TRUE;
+        foreach ($view_data['displays'] as $display_name => $lifespan) {
+          if ($lifespan != 'default') {
+            $all_default_displays = FALSE;
+          }
+        }
+        if ($all_default_displays) {
+          if ($view_data['default'] == 'none') {
+            $this->registry['views_without_output_caching'][] = $view_name;
+          }
+        }
+        else {
+          $uncached_view_string = $view_name;
+          $uncached_view_displays = array();
+          foreach ($view_data['displays'] as $display_name => $display_data) {
+            if ($display_data == 'none' || ($display_data == 'default' && $view_data['default'] == 'none')) {
+              $uncached_view_displays[] = $display_name;
+            }
+          }
+          if (!empty($uncached_view_displays)) {
+            $uncached_view_string .= ' (' . implode(', ', $uncached_view_displays) . ')';
+            $this->registry['views_without_output_caching'][] = $uncached_view_string;
+          }
+        }
+      }
+    }
+
+    if (count($this->registry['views_without_output_caching']) == 0) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+    }
+    if (site_audit_env_is_dev()) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+    }
+    if (count($this->registry['views_without_output_caching']) == count($this->registry['views'])) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+  }
+
+}

--- a/Check/Views/CacheOutput.php
+++ b/Check/Views/CacheOutput.php
@@ -4,6 +4,9 @@
  * Contains \SiteAudit\Check\Views\CacheOutput.
  */
 
+/**
+ * Class SiteAuditCheckViewsCacheOutput.
+ */
 class SiteAuditCheckViewsCacheOutput extends SiteAuditCheckAbstract {
   /**
    * Implements \SiteAudit\Check\Abstract\getLabel().

--- a/Check/Views/CacheResults.php
+++ b/Check/Views/CacheResults.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Views\CacheResults.
+ */
+
+class SiteAuditCheckViewsCacheResults extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Query results caching');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check the length of time raw query results should be cached.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+    return dt('No View is caching query results!');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    return $this->getResultWarn();
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('Every View is caching query results.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return dt('The following Views are not caching query results: @views_without_results_caching', array(
+      '@views_without_results_caching' => implode(', ', $this->registry['views_without_results_caching']),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if (!in_array($this->score, array(SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO, SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS))) {
+      $ret_val = dt('Query results should be cached for at least 1 minute.');
+      if (drush_get_option('detail')) {
+        $steps = array(
+          dt('Go to /admin/structure/views/'),
+          dt('Edit the View in question'),
+          dt('Select the Display'),
+          dt('Click Advanced'),
+          dt('Next to Caching, click to edit.'),
+          dt('Query results: (something other than Never cache)'),
+        );
+        if (drush_get_option('html')) {
+          $ret_val .= '<ol><li>' . implode('</li><li>', $steps) . '</li></ol>';
+        }
+        else {
+          foreach ($steps as $step) {
+            $ret_val .= PHP_EOL;
+            if (!drush_get_option('json')) {
+              $ret_val .= str_repeat(' ', 8);
+            }
+            $ret_val .= '- ' . $step;
+          }
+        }
+      }
+      return $ret_val;
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $this->registry['results_lifespan'] = array();
+    foreach ($this->registry['views'] as $view) {
+      // Skip views used for administration purposes.
+      if (in_array($view->get('tag'), array('admin', 'commerce'))) {
+        continue;
+      }
+      foreach ($view->get('display') as $display_name => $display) {
+        if (!isset($display['display_options']['enabled']) || $display['display_options']['enabled']) {
+          // Default display OR overriding display.
+          if (isset($display['display_options']['cache'])) {
+            if ($display['display_options']['cache']['type'] == 'none' || ($display['display_options']['cache'] == '')) {
+              if ($display_name == 'default') {
+                $this->registry['results_lifespan'][$view->get('id')]['default'] = 'none';
+              }
+              else {
+                $this->registry['results_lifespan'][$view->get('id')]['displays'][$display_name] = 'none';
+              }
+            }
+            elseif ($display['display_options']['cache']['type'] == 'time') {
+              if ($display['display_options']['cache']['options']['results_lifespan'] == 0) {
+                $lifespan = $display['display_options']['cache']['options']['results_lifespan_custom'];
+              }
+              else {
+                $lifespan = $display['display_options']['cache']['options']['results_lifespan'];
+              }
+              if ($lifespan < 1) {
+                $lifespan = 'none';
+              }
+              if ($display_name == 'default') {
+                $this->registry['results_lifespan'][$view->get('id')]['default'] = $lifespan;
+              }
+              else {
+                $this->registry['results_lifespan'][$view->get('id')]['displays'][$display_name] = $lifespan;
+              }
+            }
+            elseif ($display['display_options']['cache']['type'] == 'tag') {
+              if ($display_name == 'default') {
+                $this->registry['results_lifespan'][$view->get('id')]['default'] = 'tag';
+              }
+              else {
+                $this->registry['results_lifespan'][$view->get('id')]['displays'][$display_name] = 'tag';
+              }
+            }
+          }
+          // Display is using default display's caching.
+          else {
+            $this->registry['results_lifespan'][$view->get('id')]['displays'][$display_name] = 'default';
+          }
+        }
+      }
+    }
+    $this->registry['views_without_results_caching'] = array();
+
+    foreach ($this->registry['results_lifespan'] as $view_name => $view_data) {
+      // Views with only master display.
+      if (!isset($view_data['displays']) || (count($view_data['displays']) == 0)) {
+        if ($view_data['default'] == 'none') {
+          $this->registry['views_without_results_caching'][] = $view_name;
+        }
+      }
+      else {
+        // If all the displays are default, consolidate.
+        $all_default_displays = TRUE;
+        foreach ($view_data['displays'] as $display_name => $lifespan) {
+          if ($lifespan != 'default') {
+            $all_default_displays = FALSE;
+          }
+        }
+        if ($all_default_displays) {
+          if ($view_data['default'] == 'none') {
+            $this->registry['views_without_results_caching'][] = $view_name;
+          }
+        }
+        else {
+          $uncached_view_string = $view_name;
+          $uncached_view_displays = array();
+          foreach ($view_data['displays'] as $display_name => $display_data) {
+            if ($display_data == 'none' || ($display_data == 'default' && $view_data['default'] == 'none')) {
+              $uncached_view_displays[] = $display_name;
+            }
+          }
+          if (!empty($uncached_view_displays)) {
+            $uncached_view_string .= ' (' . implode(', ', $uncached_view_displays) . ')';
+            $this->registry['views_without_results_caching'][] = $uncached_view_string;
+          }
+        }
+      }
+    }
+
+    if (count($this->registry['views_without_results_caching']) == 0) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+    }
+    if (site_audit_env_is_dev()) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+    }
+    if (count($this->registry['views_without_results_caching']) == count($this->registry['views'])) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+  }
+
+}

--- a/Check/Views/CacheResults.php
+++ b/Check/Views/CacheResults.php
@@ -4,6 +4,9 @@
  * Contains \SiteAudit\Check\Views\CacheResults.
  */
 
+/**
+ * Class SiteAuditCheckViewsCacheResults.
+ */
 class SiteAuditCheckViewsCacheResults extends SiteAuditCheckAbstract {
   /**
    * Implements \SiteAudit\Check\Abstract\getLabel().

--- a/Check/Views/CacheResults.php
+++ b/Check/Views/CacheResults.php
@@ -19,7 +19,7 @@ class SiteAuditCheckViewsCacheResults extends SiteAuditCheckAbstract {
    * Implements \SiteAudit\Check\Abstract\getDescription().
    */
   public function getDescription() {
-    return dt('Check the length of time raw query results should be cached.');
+    return dt('Check to see if raw query results are being cached.');
   }
 
   /**
@@ -57,7 +57,7 @@ class SiteAuditCheckViewsCacheResults extends SiteAuditCheckAbstract {
    */
   public function getAction() {
     if (!in_array($this->score, array(SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO, SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS))) {
-      $ret_val = dt('Query results should be cached for at least 1 minute.');
+      $ret_val = dt('Query results should be cached for at least 1 minute or use tag caching.');
       if (drush_get_option('detail')) {
         $steps = array(
           dt('Go to /admin/structure/views/'),
@@ -65,7 +65,7 @@ class SiteAuditCheckViewsCacheResults extends SiteAuditCheckAbstract {
           dt('Select the Display'),
           dt('Click Advanced'),
           dt('Next to Caching, click to edit.'),
-          dt('Query results: (something other than Never cache)'),
+          dt('Caching: (something other than None)'),
         );
         if (drush_get_option('html')) {
           $ret_val .= '<ol><li>' . implode('</li><li>', $steps) . '</li></ol>';

--- a/Check/Views/Count.php
+++ b/Check/Views/Count.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Views\Count.
+ */
+
+/**
+ * Class SiteAuditCheckViewsCount.
+ */
+class SiteAuditCheckViewsCount extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Count');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Number of enabled Views.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    $views_count = count($this->registry['views']);
+    if (!$views_count) {
+      return dt('There are no enabled views.');
+    }
+    return dt('There are @count_views enabled views.', array(
+      '@count_views' => count($this->registry['views']),
+    ));
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return $this->getResultPass();
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Consider disabling the views module if you don\'t need it.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $this->registry['views'] = array();
+
+    $all_views = \Drupal::entityManager()->getListBuilder('view')->load();
+    foreach ($all_views['enabled'] as $view) {
+      $this->registry['views'][] = $view;
+    }
+
+    if (empty($this->registry['views'])) {
+      $this->abort = TRUE;
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+
+}

--- a/Check/Views/Enabled.php
+++ b/Check/Views/Enabled.php
@@ -59,7 +59,7 @@ class SiteAuditCheckViewsEnabled extends SiteAuditCheckAbstract {
       $this->abort = TRUE;
       return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
     }
-    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
   }
 
 }

--- a/Check/Views/Enabled.php
+++ b/Check/Views/Enabled.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Views\Enabled.
+ */
+
+/**
+ * Class SiteAuditCheckViewsEnabled.
+ */
+class SiteAuditCheckViewsEnabled extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Views status');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check to see if enabled');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+    return dt('Views is not enabled.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('Views is enabled.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    if (!\Drupal::moduleHandler()->moduleExists('views')) {
+      $this->abort = TRUE;
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+  }
+
+}

--- a/Report/Views.php
+++ b/Report/Views.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Report\Views.
+ */
+
+/**
+ * Class SiteAuditReportViews.
+ */
+class SiteAuditReportViews extends SiteAuditReportAbstract {
+  /**
+   * Implements \SiteAudit\Report\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Views');
+  }
+
+}

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -186,6 +186,19 @@ function site_audit_drush_command() {
     ),
   );
 
+  $items['audit-views'] = array(
+    'description' => dt('Audit Views.'),
+    'aliases' => array('av'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+    'options' => site_audit_common_options(),
+    'checks' => array(
+      'Enabled',
+      'Count',
+      'CacheResults',
+      'CacheOutput',
+    ),
+  );
+
   $items['audit-all'] = array(
     'description' => dt('Executes every Site Audit Report'),
     'aliases' => array('aa'),
@@ -200,6 +213,7 @@ function site_audit_drush_command() {
       'Cron',
       'Database',
       'Users',
+      'Views',
     ),
   );
 
@@ -527,5 +541,20 @@ function drush_site_audit_audit_users_validate() {
  */
 function drush_site_audit_audit_users() {
   $report = new SiteAuditReportUsers();
+  $report->render();
+}
+
+/**
+ * Audit Views validation.
+ */
+function drush_site_audit_audit_views_validate() {
+  return site_audit_version_check();
+}
+
+/**
+ * Audit Views.
+ */
+function drush_site_audit_audit_views() {
+  $report = new SiteAuditReportViews();
   $report->render();
 }


### PR DESCRIPTION
### Enabled
- [ ] Pass - `views` module is enabled
- [ ] Info - `views` module is uninstalled. This aborts the other checks of views report
### Count
- [ ] Pass - Outputs the number of views which are enabled
- [ ] Warn - If the number of views enabled are zero. Aborts the other checks
### CacheResults

There is a new type of caching provded by views in drupal 8 called `Tag`. It uses cache tags to cache the views, so the cache invalidation is not time based but cache tag based.
- [ ] Pass - If all the views use either `Tag` or `Time` caching
- [ ] Info - If some or all the views don't use caching on Pantheon dev environment
- [ ] Warn - Some of the views use caching, some don't
- [ ] Fail - None of the views use any type of caching
### CacheOutput

Similar to CacheResults check. `Tag` based caching does not have different options to enable output caching or results caching. I still exploring how and what it caches, but for this check, I think it should not fail/warn if Tag based caching is enabled, which has been implemented.
