### PR TITLE
Fix logical error in unused vocabularies check

### DIFF
--- a/Check/Content/Vocabularies.php
+++ b/Check/Content/Vocabularies.php
@@ -99,9 +99,6 @@ class SiteAuditCheckContentVocabularies extends SiteAuditCheckAbstract {
     $this->registry['vocabulary_counts'] = $this->registry['vocabulary_unused'] = array();
 
     foreach ($result as $row) {
-      if (!drush_get_option('detail')) {
-        continue;
-      }
       $label = $vocabularies[$row->vid]['label'];
       $this->registry['vocabulary_counts'][$label] = $row->count;
     }


### PR DESCRIPTION
If `detail` option is not provided, `vocabulary_count` array does not get filled. Since this array is used in calculating the unused vocabularies, this results in all the vocabularies being included in the empty list.
