### PR TITLE
Added database fragmentation check

### DIFF
--- a/Check/BestPractices/FolderStructure.php
+++ b/Check/BestPractices/FolderStructure.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\BestPractices\FolderStructure.
+ */
+
+/**
+ * Class SiteAuditCheckBestPracticesFolderStructure.
+ */
+class SiteAuditCheckBestPracticesFolderStructure extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Folder Structure');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Checks if modules/contrib and modules/custom directory is present');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('modules/contrib and modules/custom directories exist.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    if (!$this->registry['contrib'] && !$this->registry['custom']) {
+      return dT('Both modules/contrib and modules/custom directories are not present');
+    }
+    if (!$this->registry['contrib']) {
+      return dt('modules/contrib directory is not present.');
+    }
+    if (!$this->registry['custom']) {
+      return dt('modules/custom directory is not present');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Put all the contrib modules inside modules/contrib directory and custom modules inside modules/custom directory');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $this->registry['contrib'] = is_dir($drupal_root . '/modules/contrib');
+    $this->registry['custom'] = is_dir($drupal_root . '/modules/custom');
+    if (!$this->registry['contrib'] || !$this->registry['custom']) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+
+}

--- a/Check/BestPractices/FolderStructure.php
+++ b/Check/BestPractices/FolderStructure.php
@@ -61,15 +61,15 @@ class SiteAuditCheckBestPracticesFolderStructure extends SiteAuditCheckAbstract 
     $message = "";
     if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
       if (!$this->registry['contrib'] && !$this->registry['custom']) {
-        $message .= dt('Put all the contrib modules inside modules/contrib directory and custom modules inside modules/custom directory.');
+        $message .= dt('Put all the contrib modules inside the ./modules/contrib directory and custom modules inside the ./modules/custom directory.');
       }
       elseif (!$this->registry['contrib']) {
-        $message .= dt('Put all the contrib modules inside modules/contrib directory.');
+        $message .= dt('Put all the contrib modules inside the ./modules/contrib directory.');
       }
       elseif (!$this->registry['custom']) {
-        $message .= dt('Put all the custom modules inside modules/custom directory.');
+        $message .= dt('Put all the custom modules inside the ./modules/custom directory.');
       }
-      return $message . ' ' . dt('Moving modules may cause errors. Refer to https://www.drupal.org/node/183681 for information on how to move modules.');
+      return $message . ' ' . dt('Moving modules may cause errors, so refer to https://www.drupal.org/node/183681 for information on how to best proceed.');
     }
   }
 

--- a/Check/BestPractices/FolderStructure.php
+++ b/Check/BestPractices/FolderStructure.php
@@ -69,7 +69,7 @@ class SiteAuditCheckBestPracticesFolderStructure extends SiteAuditCheckAbstract 
       elseif (!$this->registry['custom']) {
         $message .= dt('Put all the custom modules inside modules/custom directory.');
       }
-      return $message . dt(' Moving modules may cause errors. Refer to https://www.drupal.org/node/183681 for information on how to move modules.');
+      return $message . ' ' . dt('Moving modules may cause errors. Refer to https://www.drupal.org/node/183681 for information on how to move modules.');
     }
   }
 

--- a/Check/BestPractices/FolderStructure.php
+++ b/Check/BestPractices/FolderStructure.php
@@ -61,15 +61,15 @@ class SiteAuditCheckBestPracticesFolderStructure extends SiteAuditCheckAbstract 
     $message = "";
     if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
       if (!$this->registry['contrib'] && !$this->registry['custom']) {
-        $message .= 'Put all the contrib modules inside modules/contrib directory and custom modules inside modules/custom directory.';
+        $message .= dt('Put all the contrib modules inside modules/contrib directory and custom modules inside modules/custom directory.');
       }
       elseif (!$this->registry['contrib']) {
-        $message .= 'Put all the contrib modules inside modules/contrib directory.';
+        $message .= dt('Put all the contrib modules inside modules/contrib directory.');
       }
       elseif (!$this->registry['custom']) {
-        $message .= 'Put all the custom modules inside modules/custom directory.';
+        $message .= dt('Put all the custom modules inside modules/custom directory.');
       }
-      return dt($message . ' Moving modules may cause errors. Refer to https://www.drupal.org/node/183681 for information on how to move modules.');
+      return $message . dt(' Moving modules may cause errors. Refer to https://www.drupal.org/node/183681 for information on how to move modules.');
     }
   }
 

--- a/Check/BestPractices/FolderStructure.php
+++ b/Check/BestPractices/FolderStructure.php
@@ -44,13 +44,13 @@ class SiteAuditCheckBestPracticesFolderStructure extends SiteAuditCheckAbstract 
    */
   public function getResultWarn() {
     if (!$this->registry['contrib'] && !$this->registry['custom']) {
-      return dT('Both modules/contrib and modules/custom directories are not present');
+      return dt('Neither modules/contrib nor modules/custom directories are present!');
     }
     if (!$this->registry['contrib']) {
-      return dt('modules/contrib directory is not present.');
+      return dt('modules/contrib directory is not present!');
     }
     if (!$this->registry['custom']) {
-      return dt('modules/custom directory is not present');
+      return dt('modules/custom directory is not present!');
     }
   }
 
@@ -58,8 +58,18 @@ class SiteAuditCheckBestPracticesFolderStructure extends SiteAuditCheckAbstract 
    * Implements \SiteAudit\Check\Abstract\getAction().
    */
   public function getAction() {
+    $message = "";
     if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
-      return dt('Put all the contrib modules inside modules/contrib directory and custom modules inside modules/custom directory');
+      if (!$this->registry['contrib'] && !$this->registry['custom']) {
+        $message .= 'Put all the contrib modules inside modules/contrib directory and custom modules inside modules/custom directory.';
+      }
+      elseif (!$this->registry['contrib']) {
+        $message .= 'Put all the contrib modules inside modules/contrib directory.';
+      }
+      elseif (!$this->registry['custom']) {
+        $message .= 'Put all the custom modules inside modules/custom directory.';
+      }
+      return dt($message . ' Moving modules may cause errors. Refer to https://www.drupal.org/node/183681 for information on how to move modules.');
     }
   }
 

--- a/Check/Database/Fragmentation.php
+++ b/Check/Database/Fragmentation.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\Database\Fragmentation.
+ */
+
+/**
+ * Class SiteAuditCheckDatabaseFragmentation.
+ */
+class SiteAuditCheckDatabaseFragmentation extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Database Fragmentation');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt("Reports all the tables with fragmentation greater than 5%");
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('None of the tables has fragmentation of more than 5%');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    arsort($this->registry['database_fragmentation']);
+    if (drush_get_option('html')) {
+      $ret_val = '<table class="table table-condensed">';
+      $ret_val .= '<thead><tr><th>' . dt('Table Name') . '</th><th>' . dt('Fragmentation Percentage') . '</th></tr></thead>';
+      $ret_val .= '<tbody>';
+      foreach ($this->registry['database_fragmentation'] as $name => $ratio) {
+        $ret_val .= '<tr>';
+        $ret_val .= '<td>' . $name . '</td>';
+        $ret_val .= '<td>' . $ratio . '</td>';
+        $ret_val .= '</tr>';
+      }
+      $ret_val .= '</tbody>';
+      $ret_val .= '</table>';
+    }
+    else {
+      $ret_val  = dt('Table Name: Fragmentation Percentage') . PHP_EOL;
+      if (!drush_get_option('json')) {
+        $ret_val .= str_repeat(' ', 4);
+      }
+      $ret_val .= '---------------------';
+      foreach ($this->registry['database_fragmentation'] as $name => $ratio) {
+        $ret_val .= PHP_EOL;
+        if (!drush_get_option('json')) {
+          $ret_val .= str_repeat(' ', 4);
+        }
+        $ret_val .= "$name: $ratio";
+      }
+    }
+    return $ret_val;
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->getScore() == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Run "OPTIMIZE TABLE" on the fragmented tables. Refer to https://dev.mysql.com/doc/refman/5.5/en/optimize-table.html for more details.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    if (version_compare(DRUSH_VERSION, 7, '>=')) {
+      $sql = drush_sql_get_class();
+      $db_spec = $sql->db_spec();
+    }
+    else {
+      $db_spec = _drush_sql_get_db_spec();
+    }
+    $sql_query  = 'SELECT TABLE_NAME AS name ';
+    $sql_query .= ', Round(DATA_LENGTH/1024/1024) as data_length ';
+    $sql_query .= ', Round(INDEX_LENGTH/1024/1024) as index_length ';
+    $sql_query .= ', Round(DATA_FREE/ 1024/1024) as data_free ';
+    $sql_query .= 'FROM information_schema.TABLES ';
+    $sql_query .= 'WHERE TABLES.DATA_FREE > 0 ';
+    $sql_query .= 'AND TABLES.table_schema = :dbname ';
+    $result = db_query($sql_query, array(
+      ':dbname' => $db_spec['database'],
+    ));
+    foreach ($result as $row) {
+      $data = $row->data_length + $row->index_length;
+      $free = $row->data_free;
+      $fragmentation_ratio = ($free / $data) * 100;
+      if ($fragmentation_ratio > 5) {
+        $this->registry['database_fragmentation'][$row->name] = $fragmentation_ratio;
+      }
+    }
+    if (empty($this->registry['database_fragmentation'])) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+  }
+
+}

--- a/Check/Database/Fragmentation.php
+++ b/Check/Database/Fragmentation.php
@@ -95,9 +95,9 @@ class SiteAuditCheckDatabaseFragmentation extends SiteAuditCheckAbstract {
       $db_spec = _drush_sql_get_db_spec();
     }
     $sql_query  = 'SELECT TABLE_NAME AS name';
-    $sql_query .= ', Round(DATA_LENGTH/1024/1024) AS data_length';
-    $sql_query .= ', Round(INDEX_LENGTH/1024/1024) AS index_length';
-    $sql_query .= ', Round(DATA_FREE/1024/1024) AS data_free';
+    $sql_query .= ', ROUND(DATA_LENGTH / 1024 / 1024) AS data_length';
+    $sql_query .= ', ROUND(INDEX_LENGTH / 1024 / 1024) AS index_length';
+    $sql_query .= ', ROUND(DATA_FREE / 1024 / 1024) AS data_free';
     $sql_query .= ' FROM information_schema.TABLES ';
     $sql_query .= ' WHERE TABLES.DATA_FREE > 0 ';
     $sql_query .= ' AND TABLES.table_schema = :dbname ';

--- a/Check/Database/Fragmentation.php
+++ b/Check/Database/Fragmentation.php
@@ -106,10 +106,12 @@ class SiteAuditCheckDatabaseFragmentation extends SiteAuditCheckAbstract {
     ));
     foreach ($result as $row) {
       $data = $row->data_length + $row->index_length;
-      $free = $row->data_free;
-      $fragmentation_ratio = $free / $data;
-      if ($fragmentation_ratio > 0.05) {
-        $this->registry['database_fragmentation'][$row->name] = $fragmentation_ratio;
+      if ($data != 0) {
+        $free = $row->data_free;
+        $fragmentation_ratio = $free / $data;
+        if ($fragmentation_ratio > 0.05) {
+          $this->registry['database_fragmentation'][$row->name] = $fragmentation_ratio;
+        }
       }
     }
     if (empty($this->registry['database_fragmentation'])) {

--- a/Check/Database/Fragmentation.php
+++ b/Check/Database/Fragmentation.php
@@ -19,7 +19,7 @@ class SiteAuditCheckDatabaseFragmentation extends SiteAuditCheckAbstract {
    * Implements \SiteAudit\Check\Abstract\getDescription().
    */
   public function getDescription() {
-    return dt("Detect table fragmentation which increases storage space and decreases I/O efficiency.");
+    return dt('Detect table fragmentation which increases storage space and decreases I/O efficiency.');
   }
 
   /**
@@ -36,7 +36,7 @@ class SiteAuditCheckDatabaseFragmentation extends SiteAuditCheckAbstract {
    * Implements \SiteAudit\Check\Abstract\getResultPass().
    */
   public function getResultPass() {
-    return dt('None of the tables has fragmentation of more than 5%');
+    return dt('None of the tables has fragmentation ration greater than 5.');
   }
 
   /**

--- a/Check/Database/Fragmentation.php
+++ b/Check/Database/Fragmentation.php
@@ -19,7 +19,7 @@ class SiteAuditCheckDatabaseFragmentation extends SiteAuditCheckAbstract {
    * Implements \SiteAudit\Check\Abstract\getDescription().
    */
   public function getDescription() {
-    return dt("Reports all the tables with fragmentation greater than 5%");
+    return dt("Detect table fragmentation which increases storage space and decreases I/O efficiency.");
   }
 
   /**
@@ -79,7 +79,7 @@ class SiteAuditCheckDatabaseFragmentation extends SiteAuditCheckAbstract {
    */
   public function getAction() {
     if ($this->getScore() == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
-      return dt('Run "OPTIMIZE TABLE" on the fragmented tables. Refer to https://dev.mysql.com/doc/refman/5.5/en/optimize-table.html for more details.');
+      return dt('Run "OPTIMIZE TABLE" on the fragmented tables. Refer to https://dev.mysql.com/doc/en/optimize-table.html for more details.');
     }
   }
 
@@ -95,9 +95,9 @@ class SiteAuditCheckDatabaseFragmentation extends SiteAuditCheckAbstract {
       $db_spec = _drush_sql_get_db_spec();
     }
     $sql_query  = 'SELECT TABLE_NAME AS name ';
-    $sql_query .= ', Round(DATA_LENGTH/1024/1024) as data_length ';
-    $sql_query .= ', Round(INDEX_LENGTH/1024/1024) as index_length ';
-    $sql_query .= ', Round(DATA_FREE/ 1024/1024) as data_free ';
+    $sql_query .= ', Round(DATA_LENGTH/1024/1024) AS data_length ';
+    $sql_query .= ', Round(INDEX_LENGTH/1024/1024) AS index_length ';
+    $sql_query .= ', Round(DATA_FREE/ 1024/1024) AS data_free ';
     $sql_query .= 'FROM information_schema.TABLES ';
     $sql_query .= 'WHERE TABLES.DATA_FREE > 0 ';
     $sql_query .= 'AND TABLES.table_schema = :dbname ';
@@ -107,7 +107,7 @@ class SiteAuditCheckDatabaseFragmentation extends SiteAuditCheckAbstract {
     foreach ($result as $row) {
       $data = $row->data_length + $row->index_length;
       $free = $row->data_free;
-      $fragmentation_ratio = ($free / $data) * 100;
+      $fragmentation_ratio = ($free / ($data + $free)) * 100;
       if ($fragmentation_ratio > 5) {
         $this->registry['database_fragmentation'][$row->name] = $fragmentation_ratio;
       }

--- a/Check/FrontEnd/GooglePageSpeed.php
+++ b/Check/FrontEnd/GooglePageSpeed.php
@@ -44,178 +44,222 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
   public function getResultInfo() {}
 
   /**
+   * Returns the rendered result from decoded json object.
+   *
+   * @param mixed $json_result
+   *   Json decodes object.
+   *
+   * @return string
+   *   Returns the rendered output.
+   */
+  public function renderResults($json_result) {
+    $ret_val = '';
+    $stats = array();
+    foreach ($json_result->pageStats as $stat_name => $count) {
+      $formatted_stat_name = ucfirst(preg_replace('/(?<!^)((?<![[:upper:]])[[:upper:]]|[[:upper:]](?![[:upper:]]))/', ' $1', $stat_name));
+      if (stripos($stat_name, 'bytes') !== FALSE) {
+        $stats[$formatted_stat_name] = round($count / 1024, 2) . 'kB';
+      }
+      else {
+        $stats[$formatted_stat_name] = $count;
+      }
+    }
+
+    // Render PageStats.
+    if (drush_get_option('html')) {
+      $ret_val .= '<h3>' . dt('Page stats') . '</h3>';
+      $ret_val .= '<dl class="dl-horizontal">';
+      foreach ($stats as $name => $count) {
+        $ret_val .= '<dt>' . $name . '</dt>';
+        $ret_val .= '<dd>' . $count . '</dd>';
+      }
+      $ret_val .= '</dl>';
+    }
+    else {
+      $ret_val .= PHP_EOL . str_repeat(' ', 6) . dt('Page stats');
+      foreach ($stats as $name => $count) {
+        $ret_val .= PHP_EOL;
+        if (!drush_get_option('json')) {
+          $ret_val .= str_repeat(' ', 8);
+        }
+        $ret_val .= '- ' . $name . ': ' . $count;
+      }
+    }
+
+    $impact_filter = drush_get_option('impact');
+
+    // Results.
+    if (drush_get_option('html')) {
+      $ret_val .= '<h3>' . dt('Detailed results') . '</h3>';
+    }
+    else {
+      $ret_val .= PHP_EOL . str_repeat(' ', 8) . dt('Detailed results:');
+    }
+    $rendered_result_count = 0;
+    // @codingStandardsIgnoreStart
+    foreach ($json_result->formattedResults->ruleResults as $resultValues) {
+      rtrim($ret_val);
+      // Filter out based on impact threshold.
+      if ($resultValues->ruleImpact < $impact_filter) {
+        continue;
+      }
+      $rendered_result_count++;
+
+      // Build impact label.
+      $impact = '';
+      if ($resultValues->ruleImpact >= 3) {
+        $impact = dt('(HIGH impact: @ruleImpact)', array(
+          '@ruleImpact' => $resultValues->ruleImpact,
+        ));
+      }
+      elseif ($resultValues->ruleImpact > 0) {
+        $impact = dt('(low impact: @ruleImpact)', array(
+          '@ruleImpact' => $resultValues->ruleImpact,
+        ));
+      }
+
+      // Render Rule, score and impact.
+      $rule_score_impact = dt('@localizedRuleName: @impact', array(
+        '@localizedRuleName' => $resultValues->localizedRuleName,
+        '@impact' => $impact,
+      ));
+      if (drush_get_option('html')) {
+        $ret_val .= '<div class="alert alert-block ';
+        if ($resultValues->ruleImpact == 0) {
+          $ret_val .= 'alert-success';
+        }
+        elseif ($resultValues->ruleImpact >= 10) {
+          $ret_val .= 'alert-danger';
+        }
+        else {
+          $ret_val .= 'alert-warning';
+        }
+        $ret_val .= '">' . $rule_score_impact . '</div>';
+      }
+      else {
+        $ret_val .= PHP_EOL;
+        if (!drush_get_option('json')) {
+          $ret_val .= str_repeat(' ', 10);
+        }
+        $ret_val .= $rule_score_impact;
+      }
+
+      // Render Summary
+      $summary = $resultValues->summary;
+      if (!isset($summary->args)) {
+        $header = google_json_text_replacement($summary->format);
+      }
+      else {
+        $header = google_json_text_replacement($summary->format, $summary->args);
+      }
+      if (drush_get_option('html')) {
+        $ret_val .= "<p>$header</p>";
+      }
+      else {
+        $ret_val .= PHP_EOL;
+        if (!drush_get_option('json')) {
+          $ret_val .= str_repeat(' ', 12);
+        }
+        $ret_val .= $header;
+      }
+
+      // URL blocks.
+      if (isset($resultValues->urlBlocks)) {
+        foreach ($resultValues->urlBlocks as $block) {
+          // @codingStandardsIgnoreEnd
+          // Header.
+          if (!isset($block->header->args)) {
+            $header = google_json_text_replacement($block->header->format);
+          }
+          else {
+            $header = google_json_text_replacement($block->header->format, $block->header->args);
+          }
+
+          $limit = drush_get_option('limit', 0);
+          if ($limit > 0 && isset($block->urls) && ($limit != count($block->urls)) && ($limit < count($block->urls))) {
+            $header .= ' ' . dt('Showing @limit out of @total total:', array(
+                '@limit' => $limit,
+                '@total' => count($block->urls),
+              ));
+          }
+
+          if (drush_get_option('html')) {
+            $ret_val .= '<blockquote>' . $header;
+          }
+          else {
+            $ret_val .= PHP_EOL;
+            if (!drush_get_option('json')) {
+              $ret_val .= str_repeat(' ', 12);
+            }
+            $ret_val .= $header;
+          }
+          if (isset($block->urls) && !empty($block->urls)) {
+            $urls = array();
+
+            $count = 0;
+            foreach ($block->urls as $url) {
+              if ($limit > 0) {
+                if (++$count > $limit) {
+                  continue;
+                }
+              }
+              $urls[] = google_json_text_replacement($url->result->format, $url->result->args);
+            }
+
+            if (drush_get_option('html')) {
+              $ret_val .= '<small>' . dt('URLs:');
+              $ret_val .= '<ul><li>' . implode('</li><li>', $urls) . '</li></ul>';
+              $ret_val .= '</small>';
+            }
+            else {
+              foreach ($urls as $url) {
+                $ret_val .= PHP_EOL;
+                if (!drush_get_option('json')) {
+                  $ret_val .= str_repeat(' ', 14);
+                }
+                $ret_val .= $url;
+              }
+            }
+          }
+          if (drush_get_option('html')) {
+            $ret_val .= '</blockquote>';
+          }
+        }
+      }
+    }
+
+    // Explain if there are no results so it doesn't look like its broken.
+    if ($rendered_result_count == 0) {
+      if ($impact_filter) {
+        $ret_val .= dt('Nice, no problems to report!');
+      }
+      else {
+        $ret_val .= dt('No results, which is unusual...');
+      }
+    }
+    return $ret_val;
+  }
+
+  /**
    * Implements \SiteAudit\Check\Abstract\getResultPass().
    */
   public function getResultPass() {
-    if ($this->abort) {
-      return;
-    }
     $ret_val = '';
-
     if (drush_get_option('detail')) {
-      // Page Stats.
-      $stats = array();
-      foreach ($this->registry['json_result']->pageStats as $stat_name => $count) {
-        $formatted_stat_name = ucfirst(preg_replace('/(?<!^)((?<![[:upper:]])[[:upper:]]|[[:upper:]](?![[:upper:]]))/', ' $1', $stat_name));
-        if (stripos($stat_name, 'bytes') !== FALSE) {
-          $stats[$formatted_stat_name] = round($count / 1024, 2) . 'kB';
-        }
-        else {
-          $stats[$formatted_stat_name] = $count;
-        }
-      }
       if (drush_get_option('html')) {
-        $ret_val .= '<h3>' . dt('Page stats') . '</h3>';
-        $ret_val .= '<dl class="dl-horizontal">';
-        foreach ($stats as $name => $count) {
-          $ret_val .= '<dt>' . $name . '</dt>';
-          $ret_val .= '<dd>' . $count . '</dd>';
-        }
-        $ret_val .= '</dl>';
+        $ret_val .= "<h2>" . dt('Desktop') . "</h2>";
       }
       else {
-        $ret_val .= dt('Page stats');
-        foreach ($stats as $name => $count) {
-          $ret_val .= PHP_EOL;
-          if (!drush_get_option('json')) {
-            $ret_val .= str_repeat(' ', 6);
-          }
-          $ret_val .= '- ' . $name . ': ' . $count;
-        }
+        $ret_val .= dt('Desktop:');
       }
-
-      $impact_filter = drush_get_option('impact');
-
-      // Results.
+      $ret_val .= $this->renderResults($this->registry['json_desktop_result']);
       if (drush_get_option('html')) {
-        $ret_val .= '<h3>' . dt('Detailed results') . '</h3>';
+        $ret_val .= "<h2>" . dt('Mobile') . "</h2>";
       }
       else {
-        $ret_val .= PHP_EOL . str_repeat(' ', 6) . dt('Detailed results:');
+        $ret_val .= PHP_EOL . str_repeat(' ', 4) . dt('Mobile');
       }
-      $rendered_result_count = 0;
-      // @codingStandardsIgnoreStart
-      foreach ($this->registry['json_result']->formattedResults->ruleResults as $resultValues) {
-        rtrim($ret_val);
-        // Filter out based on impact threshold.
-        if ($resultValues->ruleImpact < $impact_filter) {
-          continue;
-        }
-        $rendered_result_count++;
-
-        // Build impact label.
-        $impact = '';
-        if ($resultValues->ruleImpact >= 3) {
-          $impact = dt('(HIGH impact: @ruleImpact)', array(
-            '@ruleImpact' => $resultValues->ruleImpact,
-          ));
-        }
-        elseif ($resultValues->ruleImpact > 0) {
-          $impact = dt('(low impact: @ruleImpact)', array(
-            '@ruleImpact' => $resultValues->ruleImpact,
-          ));
-        }
-
-        // Render Rule, score and impact.
-        $rule_score_impact = dt('@localizedRuleName: @ruleScore @impact', array(
-          '@localizedRuleName' => $resultValues->localizedRuleName,
-          '@ruleScore' => $resultValues->ruleScore,
-          '@impact' => $impact,
-        ));
-        if (drush_get_option('html')) {
-          $ret_val .= '<div class="alert alert-block ';
-          if ($resultValues->ruleScore >= 80) {
-            $ret_val .= 'alert-success';
-          }
-          elseif ($resultValues->ruleScore >= 60) {
-            $ret_val .= 'alert-warning';
-          }
-          else {
-            $ret_val .= 'alert-danger';
-          }
-          $ret_val .= '">' . $rule_score_impact . '</div>';
-        }
-        else {
-          $ret_val .= PHP_EOL;
-          if (!drush_get_option('json')) {
-            $ret_val .= str_repeat(' ', 8);
-          }
-          $ret_val .= $rule_score_impact;
-        }
-
-        if (isset($resultValues->urlBlocks)) {
-          foreach ($resultValues->urlBlocks as $block) {
-            // @codingStandardsIgnoreEnd
-            // Header.
-            if (!isset($block->header->args)) {
-              $header = google_json_text_replacement($block->header->format);
-            }
-            else {
-              $header = google_json_text_replacement($block->header->format, $block->header->args);
-            }
-
-            $limit = drush_get_option('limit', 0);
-            if ($limit > 0 && isset($block->urls) && ($limit != count($block->urls)) && ($limit < count($block->urls))) {
-              $header .= ' ' . dt('Showing @limit out of @total total:', array(
-                  '@limit' => $limit,
-                  '@total' => count($block->urls),
-                ));
-            }
-
-            if (drush_get_option('html')) {
-              $ret_val .= '<blockquote>' . $header;
-            }
-            else {
-              $ret_val .= PHP_EOL;
-              if (!drush_get_option('json')) {
-                $ret_val .= str_repeat(' ', 10);
-              }
-              $ret_val .= $header;
-            }
-            if (isset($block->urls) && !empty($block->urls)) {
-              $urls = array();
-
-              $count = 0;
-              foreach ($block->urls as $url) {
-                if ($limit > 0) {
-                  if (++$count > $limit) {
-                    continue;
-                  }
-                }
-                $urls[] = google_json_text_replacement($url->result->format, $url->result->args);
-              }
-
-              if (drush_get_option('html')) {
-                $ret_val .= '<small>' . dt('URLs:');
-                $ret_val .= '<ul><li>' . implode('</li><li>', $urls) . '</li></ul>';
-                $ret_val .= '</small>';
-              }
-              else {
-                foreach ($urls as $url) {
-                  $ret_val .= PHP_EOL;
-                  if (!drush_get_option('json')) {
-                    $ret_val .= str_repeat(' ', 12);
-                  }
-                  $ret_val .= $url;
-                }
-              }
-            }
-            if (drush_get_option('html')) {
-              $ret_val .= '</blockquote>';
-            }
-          }
-        }
-      }
-
-      // Explain if there are no results so it doesn't look like its broken.
-      if ($rendered_result_count == 0) {
-        if ($impact_filter) {
-          $ret_val .= dt('Nice, no problems to report!');
-        }
-        else {
-          $ret_val .= dt('No results, which is unusual...');
-        }
-      }
+      $ret_val .= $this->renderResults($this->registry['json_mobile_result']);
     }
     return $ret_val;
   }
@@ -252,17 +296,22 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
       return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
     }
 
-    $pso_url = 'https://www.googleapis.com/pagespeedonline/v1/runPagespeed';
+    $pso_url = 'https://www.googleapis.com/pagespeedonline/v2/runPagespeed';
     $pso_url .= '?url=' . $url;
     $pso_url .= '&key=' . $key;
 
-    $ch = curl_init($pso_url);
+    $ch = curl_init($pso_url . '&strategy=desktop');
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
     $result = curl_exec($ch);
-    $this->registry['json_result'] = json_decode($result);
+    $this->registry['json_desktop_result'] = json_decode($result);
+
+    $ch = curl_init($pso_url . '&strategy=mobile');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+    $result = curl_exec($ch);
+    $this->registry['json_mobile_result'] = json_decode($result);
 
     // Network connection or any other problem.
-    if (is_null($this->registry['json_result'])) {
+    if (is_null($this->registry['json_desktop_result']) || is_null($this->registry['json_mobile_result'])) {
       $this->abort = TRUE;
       $this->registry['errors'][] = dt('www.googleapis.com did not provide valid json; raw result: @message', array(
         '@message' => $result,
@@ -271,10 +320,10 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
     }
 
     // Failure.
-    if (isset($this->registry['json_result']->error)) {
+    if (isset($this->registry['json_desktop_result']->error)) {
       $this->abort = TRUE;
       $this->registry['errors'] = array();
-      foreach ($this->registry['json_result']->error->errors as $error) {
+      foreach ($this->registry['json_desktop_result']->error->errors as $error) {
         $this->registry['errors'][] = dt('@message (@domain - @reason)', array(
           '@message' => $error->message,
           '@domain' => $error->domain,
@@ -283,22 +332,56 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
       }
       return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
     }
-
+    if (isset($this->registry['json_mobile_result']->error)) {
+      $this->abort = TRUE;
+      $this->registry['errors'] = array();
+      foreach ($this->registry['json_mobile_result']->error->errors as $error) {
+        $this->registry['errors'][] = dt('@message (@domain - @reason)', array(
+          '@message' => $error->message,
+          '@domain' => $error->domain,
+          '@reason' => $error->reason,
+        ));
+      }
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
     // Access problem.
-    if (isset($this->registry['json_result']->responseCode) && $this->registry['json_result']->responseCode != 200) {
+    if (isset($this->registry['json_desktop_result']->responseCode) && $this->registry['json_desktop_result']->responseCode != 200) {
       $this->abort = TRUE;
       $this->registry['errors'] = array();
       $this->registry['errors'][] = dt('@id is not accessible by PageSpeed Insights - response code (@responsecode)', array(
-        '@id' => $this->registry['json_result']->id,
-        '@responsecode' => $this->registry['json_result']->responseCode,
+        '@id' => $this->registry['json_desktop_result']->id,
+        '@responsecode' => $this->registry['json_desktop_result']->responseCode,
+      ));
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    if (isset($this->registry['json_mobile_result']->responseCode) && $this->registry['json_desktop_result']->responseCode != 200) {
+      $this->abort = TRUE;
+      $this->registry['errors'] = array();
+      $this->registry['errors'][] = dt('@id is not accessible by PageSpeed Insights - response code (@responsecode)', array(
+        '@id' => $this->registry['json_desktop_result']->id,
+        '@responsecode' => $this->registry['json_desktop_result']->responseCode,
       ));
       return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
     }
     // Overview.
-    if ($this->registry['json_result']->score > 80) {
+    // Average all scores to get the final score,
+    $score = 0;
+    $count = 0;
+    foreach ($this->registry['json_mobile_result']->ruleGroups as $group) {
+      $score += $group->score;
+      $count++;
+    }
+    foreach ($this->registry['json_desktop_result']->ruleGroups as $group) {
+      $score += $group->score;
+      $count++;
+    }
+    $score = $score / $count;
+    if ($score > 80) {
+      $this->percentOverride = $score;
       return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
     }
-    elseif ($this->registry['json_result']->score > 60) {
+    elseif ($score > 60) {
+      $this->percentOverride = $score;
       return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
     }
     return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
@@ -322,7 +405,8 @@ function google_json_text_replacement($format, $args = array()) {
     return $format;
   }
   // If there's a better way of doing this, please let me know.
-  $format_sprintf = preg_replace('/\$\d/', '%s', $format);
+  $format = preg_replace('/\{\{((BEGIN_LINK)|(END_LINK))\}\}/', '', $format);
+  $format_sprintf = preg_replace('/\{\{(.*?)\}\}/', '%s', $format);
   $values = array();
   foreach ($args as $arg) {
     $values[] = $arg->value;

--- a/Check/FrontEnd/GooglePageSpeed.php
+++ b/Check/FrontEnd/GooglePageSpeed.php
@@ -44,13 +44,13 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
   public function getResultInfo() {}
 
   /**
-   * Returns the rendered result from decoded json object.
+   * Returns the rendered result from JSON decoded object.
    *
    * @param mixed $json_result
    *   Json decodes object.
    *
    * @return string
-   *   Returns the rendered output.
+   *   Rendered Output.
    */
   public function renderResults($json_result) {
     $ret_val = '';
@@ -82,7 +82,7 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
         if (!drush_get_option('json')) {
           $ret_val .= str_repeat(' ', 8);
         }
-        $ret_val .= '- ' . $name . ': ' . $count;
+        $ret_val .= '* ' . $name . ': ' . $count;
       }
     }
 
@@ -93,7 +93,7 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
       $ret_val .= '<h3>' . dt('Detailed results') . '</h3>';
     }
     else {
-      $ret_val .= PHP_EOL . str_repeat(' ', 8) . dt('Detailed results:');
+      $ret_val .= PHP_EOL . str_repeat(' ', 6) . dt('Detailed results:');
     }
     $rendered_result_count = 0;
     // @codingStandardsIgnoreStart
@@ -139,7 +139,7 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
       else {
         $ret_val .= PHP_EOL;
         if (!drush_get_option('json')) {
-          $ret_val .= str_repeat(' ', 10);
+          $ret_val .= str_repeat(' ', 8);
         }
         $ret_val .= $rule_score_impact;
       }
@@ -158,7 +158,7 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
       else {
         $ret_val .= PHP_EOL;
         if (!drush_get_option('json')) {
-          $ret_val .= str_repeat(' ', 12);
+          $ret_val .= str_repeat(' ', 10);
         }
         $ret_val .= $header;
       }
@@ -189,7 +189,7 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
           else {
             $ret_val .= PHP_EOL;
             if (!drush_get_option('json')) {
-              $ret_val .= str_repeat(' ', 12);
+              $ret_val .= str_repeat(' ', 10);
             }
             $ret_val .= $header;
           }
@@ -215,7 +215,7 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
               foreach ($urls as $url) {
                 $ret_val .= PHP_EOL;
                 if (!drush_get_option('json')) {
-                  $ret_val .= str_repeat(' ', 14);
+                  $ret_val .= str_repeat(' ', 12);
                 }
                 $ret_val .= $url;
               }
@@ -375,7 +375,7 @@ class SiteAuditCheckFrontEndGooglePageSpeed extends SiteAuditCheckAbstract {
       $score += $group->score;
       $count++;
     }
-    $score = $score / $count;
+    $score = intval($score / $count);
     if ($score > 80) {
       $this->percentOverride = $score;
       return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -249,6 +249,7 @@ function site_audit_drush_command() {
       'Collation',
       'Engine',
       'RowCount',
+      'Fragmentation',
     ),
   );
 

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -79,6 +79,7 @@ function site_audit_drush_command() {
       'Services',
       'SitesDefault',
       'SitesSuperfluous',
+      'FolderStructure',
     ),
   );
 


### PR DESCRIPTION
Issue #51 
To test,

``` bash
 ❯ drush @d8 ad --detail                                [13:57:58]
Database: 83%
  Total size: Determine the size of the database.
    Total size: 7.41MB
  Collations: Check to see if there are any tables that aren't using UTF-8.
    Every table is using UTF-8.
  Storage Engines: Check to see if there are any tables that aren't using InnoDB.
    Every table is using InnoDB.
  Tables with at least 1000 rows: Return list of all tables with at least 1000 rows in the database.
    No tables with less than 1000 rows.
  Database Fragmentation: Reports all the tables with fragmentation greater than 5%
    Table Name: Fragmentation Percentage
    ---------------------
    cache_discovery: 400
      Run "OPTIMIZE TABLE" on the fragmented tables. Refer to https://dev.mysql.com/doc/refman/5.5/en/optimize-table.html for more details.
```

``` bash
 ❯ mysql -u root -p                                     [13:58:05]
Enter password: 
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 128
Server version: 10.0.20-MariaDB-log MariaDB Server

Copyright (c) 2000, 2015, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]> OPTIMIZE TABLE drupal8.cache_discovery;
+-------------------------+----------+----------+-------------------------------------------------------------------+
| Table                   | Op       | Msg_type | Msg_text                                                          |
+-------------------------+----------+----------+-------------------------------------------------------------------+
| drupal8.cache_discovery | optimize | note     | Table does not support optimize, doing recreate + analyze instead |
| drupal8.cache_discovery | optimize | status   | OK                                                                |
+-------------------------+----------+----------+-------------------------------------------------------------------+
2 rows in set (2.63 sec)

MariaDB [(none)]> exit
Bye
```

``` bash
 ❯ drush @d8 ad --detail                                [13:58:29]
Database: 100%
  No action required.                                   [success]
  Total size: Determine the size of the database.
    Total size: 7.55MB
  Collations: Check to see if there are any tables that aren't using UTF-8.
    Every table is using UTF-8.
  Storage Engines: Check to see if there are any tables that aren't using InnoDB.
    Every table is using InnoDB.
  Tables with at least 1000 rows: Return list of all tables with at least 1000 rows in the database.
    No tables with less than 1000 rows.
  Database Fragmentation: Reports all the tables with fragmentation greater than 5%
    None of the tables has fragmentation of more than 5%
```
