### PR TITLE
Added business logic in template files check

### DIFF
--- a/Check/Abstract.php
+++ b/Check/Abstract.php
@@ -256,4 +256,22 @@ abstract class SiteAuditCheckAbstract {
   public function getPercentOverride() {
     return $this->percentOverride;
   }
+
+  /**
+   * Gives path relative to DRUPAL_ROOT of the path is inside Drupal.
+   *
+   * @param string $filename
+   *   Absolute path of a file or directory.
+   *
+   * @return string
+   *   Path relative to Drupal root path.
+   */
+  public function getRelativePath($filename) {
+    $pos = strpos($filename, DRUPAL_ROOT);
+    if ($pos !== FALSE) {
+      $filename = substr($filename, $pos + strlen(DRUPAL_ROOT) + 1);
+    }
+    return $filename;
+  }
+
 }

--- a/Check/FrontEnd/TemplateFiles.php
+++ b/Check/FrontEnd/TemplateFiles.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\BestPractices\TemplateFiles.
+ */
+
+/**
+ * Class SiteAuditCheckFrontEndTemplateFiles.
+ */
+class SiteAuditCheckFrontEndTemplateFiles extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Template Files');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt('Check for business logic in template files of currently active theme.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    return dt('No business logic found in template files.');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    $ret_val = '';
+    if (drush_get_option('html') == TRUE) {
+      $ret_val .= '<table class="table table-condensed">';
+      $ret_val .= '<thead><tr><th>' . dt('Line') . '</th><th>' . dt('Code') . '</th></tr></thead>';
+      foreach ($this->registry['template_logic'] as $filename => $violations) {
+        $ret_val .= "<tr align='center'><td colspan='3'>File: $filename</td></tr>";
+        foreach ($violations as $violation) {
+          $ret_val .= '<tr><td>' . $violation[0] . '</td><td>' . htmlspecialchars($violation[1]) . '</td></tr>';
+        }
+      }
+      $ret_val .= '</table>';
+    }
+    else {
+      $rows = 0;
+      foreach ($this->registry['template_logic'] as $filename => $violations) {
+        if ($rows++ > 0) {
+          $ret_val .= PHP_EOL;
+          if (!drush_get_option('json')) {
+            $ret_val .= str_repeat(' ', 4);
+          }
+        }
+        $ret_val .= dt('Filename: @filename, Violations: @total', array(
+          '@filename' => $filename,
+          '@total' => count($violations),
+        ));
+        foreach ($violations as $violation) {
+          $ret_val .= PHP_EOL;
+          if (!drush_get_option('json')) {
+            $ret_val .= str_repeat(' ', 6);
+          }
+          $ret_val .= 'Line ' . $violation[0] . ' : ' . $violation[1];
+        }
+      }
+    }
+    return $ret_val;
+
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {
+    if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
+      return dt('Business logic in template files degrades performance. Remove it.');
+    }
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $theme_path = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT') . '/' . path_to_theme();
+    $command = 'find ' . $theme_path . ' -iname "*.tpl.php" ';
+    $command .= '-exec grep -n -H "db_select\|db_query\|mysql_query\|drupal_goto\|new .*(\|drupal_set_message\|drupal_get_messages\|cache_clear_all\|function .*(\|exit\|die\|arg(" {} \;';
+    $output = array();
+    exec($command, $output);
+    foreach ($output as $line) {
+      $line = explode(':', $line);
+      $this->registry['template_logic'][$line[0]][] = array($line[1], $line[2]);
+    }
+    if (!empty($this->registry['template_logic'])) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+  }
+
+}

--- a/Check/FrontEnd/TemplateFiles.php
+++ b/Check/FrontEnd/TemplateFiles.php
@@ -88,7 +88,7 @@ class SiteAuditCheckFrontEndTemplateFiles extends SiteAuditCheckAbstract {
    */
   public function getAction() {
     if ($this->score == SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN) {
-      return dt('Business logic in template files degrades performance. Remove it.');
+      return dt('Business logic in template files degrades performance. Move PHP into pre-processors and JavaScript into JavaScript files.');
     }
   }
 
@@ -103,7 +103,7 @@ class SiteAuditCheckFrontEndTemplateFiles extends SiteAuditCheckAbstract {
     exec($command, $output);
     foreach ($output as $line) {
       $line = explode(':', $line);
-      $this->registry['template_logic'][$line[0]][] = array($line[1], $line[2]);
+      $this->registry['template_logic'][$this->getRelativePath($line[0])][] = array($line[1], $line[2]);
     }
     if (!empty($this->registry['template_logic'])) {
       return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;

--- a/Report/FrontEnd.php
+++ b/Report/FrontEnd.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Report\FrontEnd.
+ */
+
+/**
+ * Class SiteAuditReportFrontEnd.
+ */
+class SiteAuditReportFrontEnd extends SiteAuditReportAbstract {
+  /**
+   * Implements \SiteAudit\Report\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('Front End');
+  }
+
+}

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -227,6 +227,16 @@ function site_audit_drush_command() {
     ),
   );
 
+  $items['audit_front_end'] = array(
+    'description' => dt("Analyze a site's front end performance."),
+    'aliases' => array('afe'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+    'options' => site_audit_common_options(),
+    'checks' => array(
+      'TemplateFiles',
+    ),
+  );
+
   $items['audit_security'] = array(
     'description' => dt('Audit the site for known security vulnerabilities.'),
     'aliases' => array('asec'),
@@ -750,6 +760,21 @@ function drush_site_audit_audit_security_validate() {
  */
 function drush_site_audit_audit_security() {
   $report = new SiteAuditReportSecurity();
+  $report->render();
+}
+
+/**
+ * Audit Front End validation.
+ */
+function drush_site_audit_audit_front_end_validate() {
+  return site_audit_version_check();
+}
+
+/**
+ * Render a Front End Report.
+ */
+function drush_site_audit_audit_front_end() {
+  $report = new SiteAuditReportFrontEnd();
   $report->render();
 }
 


### PR DESCRIPTION
Fixes #59 
Added a separate report named frontend which contains a single check. This check checks for business logic in template files.

```
 ❯ drush @d7 afe                                                                           [23:27:08]
Front End: 50%
  Template Files
    Filename:                                                                              [warning]
/home/shivanshu/webapps/drupal7/sites/all/themes/professional_theme/templates/block.tpl.php,
Violations: 1
      Line 44 :   <?php drupal_set_message('arg1 is ' . $arg1); ?>
      Business logic in template files degrades performance. Remove it.
```
