### PR TITLE
Webpagetest Report

### DIFF
--- a/Check/FrontEnd/WebPageTest.php
+++ b/Check/FrontEnd/WebPageTest.php
@@ -92,7 +92,7 @@ class SiteAuditCheckFrontEndWebPageTest extends SiteAuditCheckAbstract {
       $ret_val .= '</ul>';
     }
     else {
-      $ret_val .= $this->addSpaces(4) . 'Full Report: ' . $this->registry['webpagetest']['data']->data->summary;
+      $ret_val .= 'Full Report: ' . $this->registry['webpagetest']['data']->data->summary;
       $ret_val .= PHP_EOL . $this->addSpaces(4) . 'Location: ' . $this->registry['webpagetest']['data']->data->location;
       $ret_val .= PHP_EOL . $this->addSpaces(4) . 'Connectivity: ' . $this->registry['webpagetest']['data']->data->connectivity;
 

--- a/Check/FrontEnd/WebPageTest.php
+++ b/Check/FrontEnd/WebPageTest.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * @file
+ * Contains \SiteAudit\Check\FrontEnd\WebPageTest.
+ */
+
+/**
+ * Class SiteAuditCheckFrontEndWebPageTest.
+ */
+class SiteAuditCheckFrontEndWebPageTest extends SiteAuditCheckAbstract {
+  /**
+   * Implements \SiteAudit\Check\Abstract\getLabel().
+   */
+  public function getLabel() {
+    return dt('webpagetest.org');
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getDescription().
+   */
+  public function getDescription() {
+    return dt("Website's performance analysis by webpagetest.org");
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultFail().
+   */
+  public function getResultFail() {
+    if (!empty($this->registry['errors'])) {
+      if (drush_get_option('html')) {
+        $ret_val = '<ul><li>' . implode('</li><li>', $this->registry['errors']) . '</li></ul>';
+      }
+      else {
+        $ret_val = implode(PHP_EOL, $this->registry['errors']);
+      }
+      return $ret_val;
+    }
+    return $this->getResultPass();
+  }
+
+  /**
+   * Return a string with $number space characters if output type is not json.
+   *
+   * @param int $number
+   *   Number of spaces to be added.
+   *
+   * @return string
+   *   string containing $number spaces if output type is not json.
+   */
+  public function addSpaces($number) {
+    if (!drush_get_option('json')) {
+      return str_repeat(' ', $number);
+    }
+    return '';
+  }
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultInfo().
+   */
+  public function getResultInfo() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultPass().
+   */
+  public function getResultPass() {
+    $ret_val = '';
+    if (drush_get_option('html')) {
+      $ret_val .= '<p><b>Full Report:</b> ' . $this->registry['webpagetest']['data']->data->summary . '</p>';
+      $ret_val .= '<p><b>Location:</b> ' . $this->registry['webpagetest']['data']->data->location . '</p>';
+      $ret_val .= '<p><b>Connectivity:</b> ' . $this->registry['webpagetest']['data']->data->connectivity . '</p>';
+
+      $ret_val .= '<p><b>Scores:</b></p><ul>';
+      $ret_val .= '<li> Use persistent connections (keep alive): ' . $this->registry['webpagetest']['scores']->{'score_keep-alive'} . '</li>';
+      $ret_val .= '<li> Use gzip compression for transferring compressable responses: ' . $this->registry['webpagetest']['scores']->score_gzip . '</li>';
+      $ret_val .= '<li> Leverage browser caching of static assets: ' . $this->registry['webpagetest']['scores']->score_cache . '</li>';
+      $ret_val .= '<li> Use a CDN for all static assets: ' . $this->registry['webpagetest']['scores']->score_cdn . '</li>';
+      $ret_val .= '<li> Compress Images: ' . ($this->registry['webpagetest']['scores']->score_compress == -1 ? 'N/A' : $this->registry['webpagetest']['scores']->score_compress) . '</li>';
+      $ret_val .= '</ul>';
+
+      $ret_val .= '<p><b>Link to Images:</b></p><ul>';
+      $ret_val .= '<li> <a href="' . $this->registry['webpagetest']['images']->waterfall . '">Waterfall</a></li>';
+      $ret_val .= '<li> <a href="' . $this->registry['webpagetest']['images']->connectionView . '">Connection View</a></li>';
+      $ret_val .= '<li> <a href="' . $this->registry['webpagetest']['images']->checklist . '">Checklist</a></li>';
+      $ret_val .= '<li> <a href="' . $this->registry['webpagetest']['images']->screenShot . '">Screenshot</a></li>';
+      $ret_val .= '</ul>';
+
+      $ret_val .= '<p><b>Link to Detailed Reports:</b></p><ul>';
+      $ret_val .= '<li> <a href="' . $this->registry['webpagetest']['pages']->details . '">Details</a></li>';
+      $ret_val .= '<li> <a href="' . $this->registry['webpagetest']['pages']->checklist . '">Checklist</a></li>';
+      $ret_val .= '<li> <a href="' . $this->registry['webpagetest']['pages']->breakdown . '">Breakdown</a></li>';
+      $ret_val .= '<li> <a href="' . $this->registry['webpagetest']['pages']->domains . '">Domains</a></li>';
+      $ret_val .= '<li> <a href="' . $this->registry['webpagetest']['pages']->screenShot . '">Screenshot</a></li>';
+      $ret_val .= '</ul>';
+    }
+    else {
+      $ret_val .= $this->addSpaces(4) . 'Full Report: ' . $this->registry['webpagetest']['data']->data->summary;
+      $ret_val .= PHP_EOL . $this->addSpaces(4) . 'Location: ' . $this->registry['webpagetest']['data']->data->location;
+      $ret_val .= PHP_EOL . $this->addSpaces(4) . 'Connectivity: ' . $this->registry['webpagetest']['data']->data->connectivity;
+
+      $ret_val .= PHP_EOL . $this->addSpaces(4) . 'Scores:';
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Use persistent connections (keep alive): ' . $this->registry['webpagetest']['scores']->{'score_keep-alive'};
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Use gzip compression for transferring compressable responses: ' . $this->registry['webpagetest']['scores']->score_gzip;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Leverage browser caching of static assets: ' . $this->registry['webpagetest']['scores']->score_cache;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Use a CDN for all static assets: ' . $this->registry['webpagetest']['scores']->score_cdn;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Compress Images: ' . ($this->registry['webpagetest']['scores']->score_compress == -1 ? 'N/A' : $this->registry['webpagetest']['scores']->score_compress);
+
+      $ret_val .= PHP_EOL . $this->addSpaces(4) . 'Link to Images:';
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Waterfall: ' . $this->registry['webpagetest']['images']->waterfall;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Connection View: ' . $this->registry['webpagetest']['images']->connectionView;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Checklist: ' . $this->registry['webpagetest']['images']->checklist;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Screenshot: ' . $this->registry['webpagetest']['images']->screenShot;
+
+      $ret_val .= PHP_EOL . $this->addSpaces(4) . 'Link to Detailed Reports:';
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Details: ' . $this->registry['webpagetest']['pages']->details;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Checklist: ' . $this->registry['webpagetest']['pages']->checklist;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Breakdown: ' . $this->registry['webpagetest']['pages']->breakdown;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Domains: ' . $this->registry['webpagetest']['pages']->domains;
+      $ret_val .= PHP_EOL . $this->addSpaces(6) . '* Screenshot: ' . $this->registry['webpagetest']['pages']->screenShot;
+    }
+    return $ret_val;
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getResultWarn().
+   */
+  public function getResultWarn() {
+    return $this->getResultPass();
+  }
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\getAction().
+   */
+  public function getAction() {}
+
+  /**
+   * Implements \SiteAudit\Check\Abstract\calculateScore().
+   */
+  public function calculateScore() {
+    $this->registry['errors'] = array();
+    $key = drush_get_option('wpt-key');
+    $url = drush_get_option('url');
+    if ($key == NULL) {
+      $this->registry['errors'][] = dt('No API key provided.');
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    if ($url == NULL) {
+      $this->registry['errors'][] = dt('No url provided.');
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    // Start the test.
+    $wpt_url = 'http://www.webpagetest.org/runtest.php';
+    $wpt_url .= '?url=' . $url;
+    $wpt_url .= '&k=' . $key;
+    $wpt_url .= '&f=json';
+
+    $ch = curl_init($wpt_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+    $result = curl_exec($ch);
+    $result_json = json_decode($result);
+    // Network connection or any other problem.
+    if (is_null($result_json)) {
+      $this->abort = TRUE;
+      $this->registry['errors'] = array();
+      $this->registry['errors'][] = dt('www.webpagetest.org did not provide valid json; raw result: @message', array(
+        '@message' => $result,
+      ));
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    // Failure.
+    if ($result_json->statusCode != 200) {
+      $this->abort = TRUE;
+      $this->registry['errors'] = array($result_json->statusText);
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    $result_url = $result_json->data->jsonUrl;
+
+    // Keep checking for the results in every 5 seconds.
+    $tries = 0;
+    $found = FALSE;
+    while ($tries < 20) {
+      sleep(5);
+      $tries++;
+      $ch = curl_init($result_url);
+      curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+      $result = curl_exec($ch);
+      $result_json = json_decode($result);
+      // Network connection or any other problem.
+      if (is_null($result_json) || $result_json->statusCode != 200) {
+        continue;
+      }
+      if ($result_json->statusCode == 200) {
+        $found = TRUE;
+        break;
+      }
+    }
+    if (!$found) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+    }
+    $scores = $result_json->data->average->firstView;
+    $score = ($scores->{'score_keep-alive'} + $scores->score_gzip + $scores->score_cache + $scores->score_cdn) / 4;
+    $this->registry['webpagetest']['data'] = $result_json;
+    $this->registry['webpagetest']['images'] = $result_json->data->runs->{'1'}->firstView->images;
+    $this->registry['webpagetest']['pages'] = $result_json->data->runs->{'1'}->firstView->pages;
+    $this->registry['webpagetest']['scores'] = $scores;
+    if ($score > 80) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_PASS;
+    }
+    elseif ($score > 60) {
+      return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_WARN;
+    }
+    return SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_FAIL;
+  }
+
+}

--- a/Report/FrontEnd.php
+++ b/Report/FrontEnd.php
@@ -9,20 +9,6 @@
  */
 class SiteAuditReportFrontEnd extends SiteAuditReportAbstract {
   /**
-   * Override parent constructor to provide argument support.
-   *
-   * @param string $url
-   *   URL of site to test.
-   * @param string $key
-   *   Google API key.
-   */
-  public function __construct($url, $key) {
-    $this->registry['url'] = $url;
-    $this->registry['key'] = $key;
-    parent::__construct();
-  }
-
-  /**
    * Implements \SiteAudit\Report\Abstract\getLabel().
    */
   public function getLabel() {

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -186,12 +186,7 @@ function site_audit_drush_command() {
     'value' => 'required',
   );
 
-  $arguments_gi = array(
-    'url' => dt('The URL that you wish to test.'),
-    'key' => dt('Google Code API Key - see https://developers.google.com/speed/docs/insights/v1/getting_started#auth'),
-  );
-  $arguments_all = array_merge($arguments_all, $arguments_gi);
-  $options_gi = array(
+  $options_fe = array(
     'impact' => array(
       'description' => dt('Only show results with an impact greater than what\'s specified. 3 is considered high impact.'),
       'example-value' => dt('3'),
@@ -202,16 +197,30 @@ function site_audit_drush_command() {
       'example-value' => dt('3'),
       'value' => 'required',
     ),
+    'wpt-key' => array(
+      'description' => dt('WebPageTest API Key - see http://www.webpagetest.org/getkey.php'),
+      'example-value' => dt('3'),
+      'value' => 'required',
+    ),
+    'gi-key' => array(
+      'description' => dt('Google Code API Key - see https://developers.google.com/speed/docs/insights/v1/getting_started#auth'),
+      'value' => 'required',
+    ),
+    'url' => array(
+      'description' => dt('Limit the number of records shown for each item.'),
+      'example-value' => dt('3'),
+      'value' => 'required',
+    ),
   );
-  $options_all = array_merge($options_all, $options_gi);
+  $options_all = array_merge($options_all, $options_fe);
   $items['audit-front-end'] = array(
     'description' => dt("Analyze a site's front end performance."),
     'aliases' => array('afe'),
-    'bootstrap' => DRUSH_BOOTSTRAP_NONE,
-    'arguments' => $arguments_gi,
-    'options' => array_merge(site_audit_common_options(), $options_gi),
+    'bootstrap' => DRUSH_BOOTSTRAP_FULL,
+    'options' => array_merge(site_audit_common_options(), $options_fe),
     'checks' => array(
       'GooglePageSpeed',
+      'WebPageTest',
     ),
   );
 
@@ -585,13 +594,9 @@ function drush_site_audit_audit_extensions_validate() {
  * @param string $key
  *   Google API key.
  */
-function drush_site_audit_audit_front_end_validate($url = '', $key = '') {
-  // Ensure the API key exists.
-  if (!$key) {
-    drush_set_error('SITE_AUDIT_GOOGLE_INSIGHTS_NO_KEY', dt('An API key is required; see https://developers.google.com/speed/docs/insights/v1/getting_started#auth'));
-  }
-
+function drush_site_audit_audit_front_end_validate() {
   // Check for a valid URL.
+  $url = drush_get_option('url');
   if (filter_var($url, FILTER_VALIDATE_URL) === FALSE) {
     drush_set_error('SITE_AUDIT_GOOGLE_INSIGHTS_NO_URL', dt('A valid URL is required.'));
   }
@@ -622,7 +627,7 @@ function drush_site_audit_audit_front_end_validate($url = '', $key = '') {
  *   Google API key.
  */
 function drush_site_audit_audit_front_end($url, $key) {
-  $report = new SiteAuditReportFrontEnd($url, $key);
+  $report = new SiteAuditReportFrontEnd();
   $report->render();
 }
 

--- a/site_audit.drush.inc
+++ b/site_audit.drush.inc
@@ -216,7 +216,8 @@ function site_audit_drush_command() {
   $items['audit-front-end'] = array(
     'description' => dt("Analyze a site's front end performance."),
     'aliases' => array('afe'),
-    'bootstrap' => DRUSH_BOOTSTRAP_FULL,
+    'callback' => 'drush_site_audit_generic_callback',
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
     'options' => array_merge(site_audit_common_options(), $options_fe),
     'checks' => array(
       'GooglePageSpeed',
@@ -588,11 +589,6 @@ function drush_site_audit_audit_extensions_validate() {
 
 /**
  * Audit front end validation.
- *
- * @param string $url
- *   URL to check.
- * @param string $key
- *   Google API key.
  */
 function drush_site_audit_audit_front_end_validate() {
   // Check for a valid URL.
@@ -616,19 +612,6 @@ function drush_site_audit_audit_front_end_validate() {
       drush_set_error('SITE_AUDIT_GOOGLE_INSIGHTS_BAD_LIMIT', dt('Limit must be an integer greater than 0.'));
     }
   }
-}
-
-/**
- * Render a Google PageSpeed Insight report.
- *
- * @param string $url
- *   URL to check.
- * @param string $key
- *   Google API key.
- */
-function drush_site_audit_audit_front_end($url, $key) {
-  $report = new SiteAuditReportFrontEnd();
-  $report->render();
 }
 
 /**


### PR DESCRIPTION
Fixes #54 

I have removed `url` and `api key` as arguments and added options in their place. 
- `url`  - URL of the site
- `gi-key` - Google PageSpeed Insights API key
- `wpt-key` - WebPageTest API key

``` bash
 ❯ drush @d8 afe --url=https://drupal.org --gi-key=[Google Page Speed API Key] --wpt-key=[WebPageTest API key] --detail          [19:23:04]
Front End: 75%
  Admin Theme: Reports the current administration theme.
    Seven (seven 8.0.0-beta10)
  Google PageSpeed Insights: Analysis by the Google PageSpeed Insights service
    Page stats
      - Number Resources: 54
      - Number Hosts: 20
      - Total Request Bytes: 9.91kB
      - Number Static Resources: 23
      - Html Response Bytes: 27.21kB
      - Css Response Bytes: 133.04kB
      - Image Response Bytes: 579.64kB
      - Javascript Response Bytes: 322.61kB
      - Other Response Bytes: 11.02kB
      - Number Js Resources: 12
      - Number Css Resources: 2
      Detailed results:
        Avoid landing page redirects:  
          Your page has no redirects. Learn more about avoiding landing page redirects.
        Enable compression:  (low impact: 0.5096)
          Compressing resources with gzip or deflate can reduce the number of bytes sent over the network.
          Enable compression for the following resources to reduce their transfer size by https://developers.google.com/speed/docs/insights/EnableCompression (4.6KiB reduction).
            Compressing https://www.drupal.org/sites/all/modules/drupalorg/drupalorg/images/d8.svg could save 2.8KiB (60% reduction).
            Compressing https://www.drupal.org/sites/all/themes/bluecheese/images/community-users.svg could save 1.1KiB (51% reduction).
            Compressing https://www.drupal.org/sites/all/themes/bluecheese/images/community-commits.svg could save 683B (48% reduction).
        Leverage browser caching:  (low impact: 2.483630952381)
          Setting an expiry date or a maximum age in the HTTP headers for static resources instructs the browser to load previously downloaded resources from local disk rather than over the network.
          Leverage browser caching for the following cacheable resources:
            https://tag.perfectaudience.com/serve/54419274f6c96ed073000003.js (30 minutes)
            https://pagead2.googlesyndication.com/pagead/osd.js (60 minutes)
            https://partner.googleadservices.com/gampad/google_service.js (60 minutes)
            https://securepubads.g.doubleclick.net/gampad/google_ads.js (60 minutes)
            https://www.google-analytics.com/analytics.js (2 hours)
        Reduce server response time:  (low impact: 0.18)
          In our test, your server responded in 0.22 seconds. There are many factors that can slow down your server response time. Please read our recommendations to learn how you can monitor and measure where your server is spending the most time.
        Minify CSS:  
          Your CSS is minified. Learn more about minifying CSS.
        Minify HTML:  
          Your HTML is minified. Learn more about minifying HTML.
        Minify JavaScript:  (low impact: 0.9018)
          Compacting JavaScript code can save many bytes of data and speed up downloading, parsing, and execution time.
          Minify JavaScript for the following resources to reduce their size by https://developers.google.com/speed/docs/insights/MinifyResources (8.3KiB reduction).
            Minifying https://www.drupal.org/files/advagg_js/js__UiO29A8qiU-liB_96gCC8E9JKDzRn317nHrd6s0stps__AwigsEBkeDuYYEcio1o-kRLmSuICds4-G7yNidtd27A__GKPXQ36vHDFbrOKQtK_IEMxZ1RUffPGNLuaADE9Tq48.js could save 4.3KiB (14% reduction) after compression.
            Minifying https://www.drupal.org/files/advagg_js/js__WPTjldjlQG-ibnWOs4_5_ib8UtoNz1n3pDCPhynm6Uk__v7i3ET2StaZyTCGFZWQjmnMpfiVL5fS4-7yid_J_BJY__GKPXQ36vHDFbrOKQtK_IEMxZ1RUffPGNLuaADE9Tq48.js could save 1.7KiB (35% reduction) after compression.
            Minifying https://www.drupal.org/files/advagg_js/js__F-D1Wr4s7lvQ_5eZ1uikRth42rCUHezP7S--qIwe4BE__BENqbZRxUBWhW4xtQpgAaYXNTGo08uOCQ9RnS4xs6mE__GKPXQ36vHDFbrOKQtK_IEMxZ1RUffPGNLuaADE9Tq48.js could save 1.6KiB (39% reduction) after compression.
            Minifying https://www.drupal.org/files/advagg_js/js__EMCfKGudr6YbSRPLPtEJCm6hBbDPYG9OmcnCkXac-lw___4lW3RAogR_Dg7YQ0GivoywrPe3IWr3Aivpj4b4lFKQ__GKPXQ36vHDFbrOKQtK_IEMxZ1RUffPGNLuaADE9Tq48.js could save 772B (11% reduction) after compression.
        Eliminate render-blocking JavaScript and CSS in above-the-fold content:  (HIGH impact: 18)
          Your page has 2 blocking script resources and 2 blocking CSS resources. This causes a delay in rendering your page.
          None of the above-the-fold content on your page could be rendered without waiting for the following resources to load. Try to defer or asynchronously load blocking resources, or inline the critical portions of those resources directly in the HTML.
          Remove render-blocking JavaScript:
            https://partner.googleadservices.com/gampad/google_service.js
            https://securepubads.g.doubleclick.net/gampad/google_ads.js
          Optimize CSS Delivery of the following:
            https://www.drupal.org/files/advagg_css/css__sOq59WKNiWOgbu4pGFLqc02-UxptzM-43WLTi07EISQ___n4Hsqnm5n4Q3o61O6Nwbi2uyaDvjIjy3P1ub9akHgM__GKPXQ36vHDFbrOKQtK_IEMxZ1RUffPGNLuaADE9Tq48.css
            https://www.drupal.org/files/advagg_css/css__FGk3wEy-4xUHLoLxx47psMf0CNXbYM7sWoYboFOgmrQ__7XHzNWpSMplHh-OYgACTDw2YUOmlyGI8Y6Y9OpJ66VU__GKPXQ36vHDFbrOKQtK_IEMxZ1RUffPGNLuaADE9Tq48.css
        Optimize images:  (HIGH impact: 29.0861)
          Properly formatting and compressing images can save many bytes of data.
          Optimize the following images to reduce their size by https://developers.google.com/speed/docs/insights/OptimizeImages (284KiB reduction).
            Compressing and resizing https://www.drupal.org/files/styles/case-4-2x/public/Drupal-case-study-1.png?itok=QeT_-GJq could save 144.5KiB (70% reduction).
            Compressing and resizing https://www.drupal.org/files/styles/case-4-2x/public/acronis_620_440.png?itok=m2Jcbj9K could save 107.6KiB (70% reduction).
            Compressing and resizing https://www.drupal.org/files/styles/case-4-2x/public/first4numbers-by-website-express.jpg?itok=hllwuASQ could save 30.6KiB (70% reduction).
            Losslessly compressing https://www.drupal.org/sites/all/themes/bluecheese/images/sprites.png could save 1.3KiB (12% reduction).
        Prioritize visible content:  
          You have the above-the-fold content properly prioritized. Learn more about prioritizing visible content.
      Full report at https://developers.google.com/speed/pagespeed/insights
  webpagetest.org: Website's performance analysis by webpagetest.org
    Full Report: http://www.webpagetest.org/results.php?test=150817_CA_PTW
    Location: Dulles:Chrome:Chrome
    Connectivity: Cable
    Scores:
      * Use persistent connections (keep alive): 100
      * Use gzip compression for transferring compressable responses: 100
      * Leverage browser caching of static assets: 73
      * Use a CDN for all static assets: 100
      * Compress Images: N/A
    Link to Images:
      * Waterfall: http://www.webpagetest.org/results/15/08/17/CA/PTW/1_waterfall.png
      * Connection View: http://www.webpagetest.org/results/15/08/17/CA/PTW/1_connection.png
      * Checklist: http://www.webpagetest.org/results/15/08/17/CA/PTW/1_optimization.png
      * Screenshot: http://www.webpagetest.org/getfile.php?test=150817_CA_PTW&file=1_screen.jpg
    Link to Detailed Reports:
      * Details: http://www.webpagetest.org/details.php?test=150817_CA_PTW&run=1&cached=0
      * Checklist: http://www.webpagetest.org/performance_optimization.php?test=150817_CA_PTW&run=1&cached=0
      * Breakdown: http://www.webpagetest.org/breakdown.php?test=150817_CA_PTW&run=1&cached=0
      * Domains: http://www.webpagetest.org/domains.php?test=150817_CA_PTW&run=1&cached=0
      * Screenshot: http://www.webpagetest.org/screen_shot.php?test=150817_CA_PTW&run=1&cached=0
```
