### PR TITLE
Change the usage of  config array to new config system

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ System check in the Status report, use the following convention:
 
 Multiple skip values can be used, comma separated.
 
-If you want to permanently opt-out of a check, use the $conf array in
+If you want to permanently opt-out of a check, use the $config array in
 settings.php with the individual check names in the same format as the skip
 option. For example, to permanently opt-out of the PageCompression check in the
 Cache report:
 
 ```php
-$conf['site_audit']['opt_out']['CachePageCompression'] = TRUE;
+$config['site_audit']['opt_out']['CachePageCompression'] = TRUE;
 ```
 
 ## Vendor specific options
@@ -148,10 +148,10 @@ Provide a comma separated list of paths (files or directories) in the option
 drush audit-codebase --custom-code="modules/custom,modules/features"
 ```
 
-Or provide an array of custom code paths in `$conf` array in `settings.php`:
+Or provide an array of custom code paths in `$config` array in `settings.php`:
 
 ```php
-$conf['site_audit']['custom-code'] = array(
+$config['site_audit']['custom-code'] = array(
   'modules/custom',
   'modules/features',
 );

--- a/Report/Abstract.php
+++ b/Report/Abstract.php
@@ -64,8 +64,6 @@ abstract class SiteAuditReportAbstract {
    * Constructor; loads and executes checks based on the name of this report.
    */
   public function __construct() {
-    global $conf;
-
     $base_class_name = 'SiteAuditCheck' . $this->getReportName();
     $percent_override = NULL;
 
@@ -90,10 +88,11 @@ abstract class SiteAuditReportAbstract {
       }
       return drush_set_error('SITE_AUDIT_NO_CHECKS', dt('No checks are available!'));
     }
-
+    $config = \Drupal::config('site_audit');
     foreach ($checks_to_perform as $check_name) {
       $class_name = $base_class_name . $check_name;
-      $check = new $class_name($this->registry, isset($conf['site_audit']['opt_out'][$this->getReportName() . $check_name]));
+      $opt_out = $config->get('opt_out.' . $this->getReportName() . $check_name) != NULL;
+      $check = new $class_name($this->registry, $opt_out);
 
       // Calculate score.
       if ($check->getScore() != SiteAuditCheckAbstract::AUDIT_CHECK_SCORE_INFO) {


### PR DESCRIPTION
- In checking whether a check has been opted out, the older $conf array from Drupal 7 was being used. I have changed it to use the config management system in Drupal 8.
- In Drupal 8 in settings.php, `$config` array is used instead of `$conf` array from Drupal 7. The readme still had references to `$conf`. I have fixed it.
