### PR TITLE
#75 change permissions for site audit report to 'administer site configuration'

### DIFF
--- a/site_audit.routing.yml
+++ b/site_audit.routing.yml
@@ -4,4 +4,4 @@ site_audit.site_audit_controller_audit:
     _controller: '\Drupal\site_audit\Controller\SiteAuditController::audit'
     _title: 'Audit'
   requirements:
-    _permission: 'access content'
+    _permission: 'administer site configuration'


### PR DESCRIPTION
this changes the permission to one that only site administrators have fixing issue #75 